### PR TITLE
ATO-933: Generate access token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "body-parser": "^1.20.2",
         "express": "^4.19.2",
+        "jose": "^5.6.3",
         "pino": "^9.3.2"
       },
       "devDependencies": {
@@ -5241,6 +5242,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.6.3.tgz",
+      "integrity": "sha512-1Jh//hEEwMhNYPDDLwXHa2ePWgWiFNNUadVmguAAw2IJ6sj9mNxV5tGXJNqlMkJAybF6Lgw1mISDxTePP/187g==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "body-parser": "^1.20.2",
     "express": "^4.19.2",
+    "jose": "^5.6.3",
     "pino": "^9.3.2"
   },
   "devDependencies": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,7 @@
 import express, { Application, Express, Request, Response } from "express";
 import { configController } from "./components/config/config-controller";
 import bodyParser from "body-parser";
+import { tokenController } from "./components/token/token-controller";
 
 const createApp = (): Application => {
   const app: Express = express();
@@ -14,6 +15,7 @@ const createApp = (): Application => {
   });
 
   app.post("/config", configController);
+  app.post("/token", tokenController);
 
   return app;
 };

--- a/src/components/token/helper/create-access-token.ts
+++ b/src/components/token/helper/create-access-token.ts
@@ -1,0 +1,54 @@
+import { randomUUID } from "crypto";
+import {
+  ACCESS_TOKEN_EXPIRY,
+  ISSUER_VALUE,
+  SESSION_ID,
+} from "../../../constants";
+import { Config } from "../../../config";
+import { logger } from "../../../logger";
+import { signToken } from "./sign-token";
+
+type AccessTokenClaims = {
+  exp: number;
+  iat: number;
+  iss: string;
+  jti: string;
+  client_id: string;
+  sub: string;
+  sid: string;
+  scope: string[];
+};
+
+export const createAccessToken = async (
+  requestScopes: string[]
+): Promise<string> => {
+  logger.info("Creating access token");
+  const config = Config.getInstance();
+  const accessTokenClaims = createAccessTokenClaimSet(requestScopes, config);
+  const accessToken = await signToken(accessTokenClaims);
+  return accessToken;
+};
+
+const createAccessTokenClaimSet = (
+  scope: string[],
+  clientConfig: Config
+): AccessTokenClaims => {
+  const iat = Math.floor(Date.now() / 1000);
+  const exp = iat + ACCESS_TOKEN_EXPIRY;
+  const jti = randomUUID();
+  const sid = SESSION_ID;
+  const sub = clientConfig.getSub();
+  const clientId = clientConfig.getClientId();
+  //TODO: Add claims from AuthRequestParam store when identity attributes supported
+
+  return {
+    exp,
+    iat,
+    iss: ISSUER_VALUE,
+    jti,
+    client_id: clientId,
+    sub,
+    sid,
+    scope,
+  };
+};

--- a/src/components/token/helper/create-access-token.ts
+++ b/src/components/token/helper/create-access-token.ts
@@ -7,17 +7,7 @@ import {
 import { Config } from "../../../config";
 import { logger } from "../../../logger";
 import { signToken } from "./sign-token";
-
-type AccessTokenClaims = {
-  exp: number;
-  iat: number;
-  iss: string;
-  jti: string;
-  client_id: string;
-  sub: string;
-  sid: string;
-  scope: string[];
-};
+import { AccessTokenClaims } from "../../../types/access-token-claims";
 
 export const createAccessToken = async (
   requestScopes: string[]

--- a/src/components/token/helper/create-id-token.ts
+++ b/src/components/token/helper/create-id-token.ts
@@ -1,0 +1,75 @@
+import { createHash } from "crypto";
+import { Config } from "../../../config";
+import {
+  ID_TOKEN_EXPIRY,
+  ISSUER_VALUE,
+  SESSION_ID,
+  TRUSTMARK_URL,
+} from "../../../constants";
+import { logger } from "../../../logger";
+import AuthRequestParameters from "src/types/auth-request-parameters";
+import { signToken } from "./sign-token";
+
+type IdTokenClaims = {
+  at_hash: string;
+  sub: string;
+  aud: string;
+  iss: string;
+  vot: string;
+  exp: number;
+  iat: number;
+  nonce: string;
+  vtm: string;
+  sid: string;
+};
+
+export const createIdToken = async (
+  authRequestParams: AuthRequestParameters,
+  accessToken: string
+): Promise<string> => {
+  logger.info("Creating Id token");
+
+  const clientConfig = Config.getInstance();
+  const idTokenClaims = createIdTokenClaimSet(
+    clientConfig,
+    authRequestParams,
+    accessToken
+  );
+
+  const signedIdToken = await signToken(idTokenClaims);
+
+  logger.info("Id token created");
+
+  return signedIdToken;
+};
+
+const createIdTokenClaimSet = (
+  clientConfig: Config,
+  authRequestParams: AuthRequestParameters,
+  accessToken: string
+): IdTokenClaims => {
+  const iat = Math.floor(Date.now() / 1000);
+  const exp = iat + ID_TOKEN_EXPIRY;
+
+  return {
+    iat,
+    exp,
+    at_hash: generateAccessTokenHash(accessToken),
+    sub: clientConfig.getSub(),
+    aud: clientConfig.getClientId(),
+    iss: ISSUER_VALUE,
+    sid: SESSION_ID,
+    vot: authRequestParams.vtr.credentialTrust,
+    nonce: authRequestParams.nonce,
+    vtm: TRUSTMARK_URL,
+  };
+};
+
+const generateAccessTokenHash = (accessToken: string): string => {
+  //This assumes our hashing algorithm will always be sha256
+  //given we only support RS256 and ES256 I think this is correct
+  const hash = createHash("sha256");
+  const hashedToken = hash.update(Buffer.from(accessToken, "ascii")).digest();
+  const firstHalf = hashedToken.subarray(0, Math.ceil(hashedToken.length / 2));
+  return firstHalf.toString("base64url");
+};

--- a/src/components/token/helper/create-id-token.ts
+++ b/src/components/token/helper/create-id-token.ts
@@ -9,19 +9,7 @@ import {
 import { logger } from "../../../logger";
 import AuthRequestParameters from "src/types/auth-request-parameters";
 import { signToken } from "./sign-token";
-
-type IdTokenClaims = {
-  at_hash: string;
-  sub: string;
-  aud: string;
-  iss: string;
-  vot: string;
-  exp: number;
-  iat: number;
-  nonce: string;
-  vtm: string;
-  sid: string;
-};
+import { IdTokenClaims } from "../../../types/id-token-claims";
 
 export const createIdToken = async (
   authRequestParams: AuthRequestParameters,

--- a/src/components/token/helper/key-helpers.ts
+++ b/src/components/token/helper/key-helpers.ts
@@ -1,0 +1,25 @@
+import { importPKCS8, KeyLike } from "jose";
+import {
+  EC_KEY_ID,
+  EC_PRIVATE_TOKEN_SIGNING_KEY,
+  RSA_KEY_ID,
+  RSA_PRIVATE_TOKEN_SIGNING_KEY,
+} from "../../../constants";
+
+export const getTokenSigningKey = (
+  tokenSigningAlgorithm: string
+): Promise<KeyLike> => {
+  if (tokenSigningAlgorithm === "ES256") {
+    return importPKCS8(EC_PRIVATE_TOKEN_SIGNING_KEY, "EC");
+  } else {
+    return importPKCS8(RSA_PRIVATE_TOKEN_SIGNING_KEY, "RSA");
+  }
+};
+
+export const getKeyId = (tokenSigningAlgorithm: string): string => {
+  if (tokenSigningAlgorithm === "ES256") {
+    return EC_KEY_ID;
+  } else {
+    return RSA_KEY_ID;
+  }
+};

--- a/src/components/token/helper/sign-token.ts
+++ b/src/components/token/helper/sign-token.ts
@@ -1,0 +1,27 @@
+import { SignJWT } from "jose";
+import { Config } from "../../../config";
+import { getKeyId, getTokenSigningKey } from "./key-helpers";
+import { logger } from "../../../logger";
+
+export const signToken = async (
+  claimSet: Record<string, unknown>
+): Promise<string> => {
+  const clientConfig = Config.getInstance();
+  const tokenSigningAlgorithm = clientConfig.getIdTokenSigningAlgorithm();
+
+  const privateKey = await getTokenSigningKey(tokenSigningAlgorithm);
+  const kid = getKeyId(tokenSigningAlgorithm);
+
+  const signedJWT = await new SignJWT(claimSet)
+    .setProtectedHeader({
+      alg: tokenSigningAlgorithm,
+      kid,
+    })
+    .sign(privateKey);
+
+  logger.info(
+    `Created Signed JWT with signing algorithm: "${tokenSigningAlgorithm}" using keyId: ${kid}`
+  );
+
+  return signedJWT;
+};

--- a/src/components/token/tests/helper/create-access-token.test.ts
+++ b/src/components/token/tests/helper/create-access-token.test.ts
@@ -1,0 +1,97 @@
+jest.mock("crypto", () => ({
+  randomUUID: () => "1234567",
+}));
+
+import { Config } from "../../../../config";
+import {
+  ACCESS_TOKEN_EXPIRY,
+  EC_KEY_ID,
+  ISSUER_VALUE,
+  RSA_KEY_ID,
+  SESSION_ID,
+} from "../../../../constants";
+import { createAccessToken } from "../../helper/create-access-token";
+
+describe("createAccessToken tests", () => {
+  const testTimestamp = 1723707024;
+  const testClientId = "testClientId";
+  const testSubClaim =
+    "urn:fdc:gov.uk:2022:56P4CMsGh_02YOlWpd8PAOI-2sVlB2nsNU7mcLZYhYw=";
+
+  const clientIdSpy = jest.spyOn(Config.getInstance(), "getClientId");
+  const subSpy = jest.spyOn(Config.getInstance(), "getSub");
+  const tokenSigningAlgorithmSpy = jest.spyOn(
+    Config.getInstance(),
+    "getIdTokenSigningAlgorithm"
+  );
+
+  const decodeTokenPart = (part: string) =>
+    JSON.parse(Buffer.from(part, "base64url").toString());
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(testTimestamp);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("returns a signed jwt using RS256", async () => {
+    tokenSigningAlgorithmSpy.mockReturnValue("RS256");
+    subSpy.mockReturnValue(testSubClaim);
+    clientIdSpy.mockReturnValue(testClientId);
+
+    const accessToken = await createAccessToken(["openid"]);
+    const tokenParts = accessToken.split(".");
+
+    const header = decodeTokenPart(tokenParts[0]);
+    const payload = decodeTokenPart(tokenParts[1]);
+
+    expect(tokenParts.length).toBe(3);
+    expect(header).toStrictEqual({
+      alg: "RS256",
+      kid: RSA_KEY_ID,
+    });
+    expect(payload).toStrictEqual({
+      iat: Math.floor(testTimestamp / 1000),
+      exp: Math.floor(testTimestamp / 1000) + ACCESS_TOKEN_EXPIRY,
+      iss: ISSUER_VALUE,
+      jti: "1234567",
+      client_id: testClientId,
+      sub: testSubClaim,
+      sid: SESSION_ID,
+      scope: ["openid"],
+    });
+    expect(typeof tokenParts[2]).toBe("string");
+  });
+
+  it("returns a signed jwt using ES256", async () => {
+    tokenSigningAlgorithmSpy.mockReturnValue("ES256");
+    subSpy.mockReturnValue(testSubClaim);
+    clientIdSpy.mockReturnValue(testClientId);
+
+    const accessToken = await createAccessToken(["openid"]);
+    const tokenParts = accessToken.split(".");
+
+    const header = decodeTokenPart(tokenParts[0]);
+    const payload = decodeTokenPart(tokenParts[1]);
+
+    expect(tokenParts.length).toStrictEqual(3);
+    expect(header).toStrictEqual({
+      alg: "ES256",
+      kid: EC_KEY_ID,
+    });
+    expect(payload).toStrictEqual({
+      iat: Math.floor(testTimestamp / 1000),
+      exp: Math.floor(testTimestamp / 1000) + ACCESS_TOKEN_EXPIRY,
+      iss: ISSUER_VALUE,
+      jti: "1234567",
+      client_id: testClientId,
+      sub: testSubClaim,
+      sid: SESSION_ID,
+      scope: ["openid"],
+    });
+    expect(typeof tokenParts[2]).toBe("string");
+  });
+});

--- a/src/components/token/tests/helper/create-id-token.test.ts
+++ b/src/components/token/tests/helper/create-id-token.test.ts
@@ -1,0 +1,110 @@
+import { Config } from "../../../../config";
+import {
+  ID_TOKEN_EXPIRY,
+  EC_KEY_ID,
+  ISSUER_VALUE,
+  RSA_KEY_ID,
+  TRUSTMARK_URL,
+  SESSION_ID,
+} from "../../../../constants";
+import AuthRequestParameters from "../../../../types/auth-request-parameters";
+import { createIdToken } from "../../helper/create-id-token";
+
+describe("createIdToken tests", () => {
+  const mockAuthRequestParams: AuthRequestParameters = {
+    claims: [],
+    nonce: "nonce-1238rhbh4r84=4rij=r4r",
+    scopes: ["openid"],
+    redirectUri: "https://example.com/authentication-callback/",
+    vtr: {
+      credentialTrust: "Cl.Cm",
+    },
+  };
+  const testTimestamp = 1723707024;
+  const testClientId = "testClientId";
+  const testSubClaim =
+    "urn:fdc:gov.uk:2022:56P4CMsGh_02YOlWpd8PAOI-2sVlB2nsNU7mcLZYhYw=";
+  const testAccessToken =
+    "eyJhbGciOiJSUzI1NiIsImtpZCI6IjczMzRiNzE4LTNmMjktNDRlZi04YjY1LWUyNjZhMTdkYWVhNSJ9.eyJleHAiOjkzNjQ4OTc4MSwiaWF0Ijo5MzY0ODk2MDEsImlzcyI6Imh0dHBzOi8vb2lkYy50ZXN0LmFjY291bnQuZ292LnVrIiwianRpIjoiMTIzNDU2NyIsImNsaWVudF9pZCI6InRlc3RDbGllbnRJZCIsInN1YiI6InVybjpmZGM6Z292LnVrOjIwMjI6NTZQNENNc0doXzAyWU9sV3BkOFBBT0ktMnNWbEIybnNOVTdtY0xaWWhZdz0iLCJzaWQiOiIxMjM0NTY3Iiwic2NvcGUiOlsib3BlbmlkIl19.GDDz3DcWSUCWMT8OkxZvU8ffiAjOKcNNaW23RzlEBer3G4Xz5Sp7moGtbP4vcfXT_pLUy-_YTIsiJ9r-A1gchhmx_qbfnWcqHxwj3DFYZ_Q16XgpB_7o_MtsiY1aAhqd8-zywTg25aczMHPtZMLVdYx9vw8zlF9iI9sOscS-s5Bje1yZ6ZmbHseHYVa8yJmZIjoKcdnGQXQwGQFp1KyzkA2gJxnR19Nc8O9oM4PA5y6uBCme3YTknei3T3tfJrPiBevtdvr9SV5fBTK2MrPzHao51_8nT841TdnMbHWxYp0FHTiBw7aAQO2VoKQ6Zku5CqBd3dyeQy_sZDNOFrDOTA";
+
+  const clientIdSpy = jest.spyOn(Config.getInstance(), "getClientId");
+  const subSpy = jest.spyOn(Config.getInstance(), "getSub");
+  const tokenSigningAlgorithmSpy = jest.spyOn(
+    Config.getInstance(),
+    "getIdTokenSigningAlgorithm"
+  );
+
+  const decodeTokenPart = (part: string) =>
+    JSON.parse(Buffer.from(part, "base64url").toString());
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(testTimestamp);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("returns a signed Id token using RS256", async () => {
+    tokenSigningAlgorithmSpy.mockReturnValue("RS256");
+    subSpy.mockReturnValue(testSubClaim);
+    clientIdSpy.mockReturnValue(testClientId);
+
+    const IdToken = await createIdToken(mockAuthRequestParams, testAccessToken);
+    const tokenParts = IdToken.split(".");
+
+    const header = decodeTokenPart(tokenParts[0]);
+    const payload = decodeTokenPart(tokenParts[1]);
+
+    expect(tokenParts.length).toBe(3);
+    expect(header).toStrictEqual({
+      alg: "RS256",
+      kid: RSA_KEY_ID,
+    });
+    expect(payload).toStrictEqual({
+      iat: Math.floor(testTimestamp / 1000),
+      exp: Math.floor(testTimestamp / 1000) + ID_TOKEN_EXPIRY,
+      iss: ISSUER_VALUE,
+      aud: testClientId,
+      sub: testSubClaim,
+      sid: SESSION_ID,
+      at_hash: "oB7bgQoIL9clDcgMdS4Ydg",
+      vtm: TRUSTMARK_URL,
+      vot: "Cl.Cm",
+      nonce: mockAuthRequestParams.nonce,
+    });
+    expect(typeof tokenParts[2]).toBe("string");
+  });
+
+  it("returns a signed Id Token using ES256", async () => {
+    tokenSigningAlgorithmSpy.mockReturnValue("ES256");
+    subSpy.mockReturnValue(testSubClaim);
+    clientIdSpy.mockReturnValue(testClientId);
+
+    const idToken = await createIdToken(mockAuthRequestParams, testAccessToken);
+    const tokenParts = idToken.split(".");
+
+    const header = decodeTokenPart(tokenParts[0]);
+    const payload = decodeTokenPart(tokenParts[1]);
+
+    expect(tokenParts.length).toBe(3);
+    expect(header).toStrictEqual({
+      alg: "ES256",
+      kid: EC_KEY_ID,
+    });
+    expect(payload).toStrictEqual({
+      iat: Math.floor(testTimestamp / 1000),
+      exp: Math.floor(testTimestamp / 1000) + ID_TOKEN_EXPIRY,
+      iss: ISSUER_VALUE,
+      aud: testClientId,
+      sub: testSubClaim,
+      sid: SESSION_ID,
+      at_hash: "oB7bgQoIL9clDcgMdS4Ydg",
+      vtm: TRUSTMARK_URL,
+      vot: mockAuthRequestParams.vtr.credentialTrust,
+      nonce: mockAuthRequestParams.nonce,
+    });
+    expect(typeof tokenParts[2]).toBe("string");
+  });
+});

--- a/src/components/token/token-controller.ts
+++ b/src/components/token/token-controller.ts
@@ -1,0 +1,89 @@
+import { Request, Response } from "express";
+import { logger } from "../../logger";
+import { Config } from "../../config";
+import { createAccessToken } from "./helper/create-access-token";
+import { createIdToken } from "./helper/create-id-token";
+import { TokenRequestError } from "../../errors/token-request-error";
+import { ParseRequestError } from "../../errors/parse-request-error";
+import { parseTokenRequest } from "../../parse/parse-token-request";
+
+export const tokenController = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  try {
+    const config = Config.getInstance();
+
+    const parsedTokenRequest = await parseTokenRequest(req.body, config);
+
+    const authCodeParams = config.getAuthCodeRequestParams(
+      parsedTokenRequest.tokenRequest.code
+    );
+
+    if (!authCodeParams) {
+      logger.warn(
+        { code: parsedTokenRequest.tokenRequest.code },
+        "Could not find auth code params for provided auth code"
+      );
+      throw new TokenRequestError({
+        errorCode: "invalid_grant",
+        errorDescription: "Invalid grant",
+        httpStatusCode: 400,
+      });
+    }
+
+    if (
+      authCodeParams.redirectUri !== parsedTokenRequest.tokenRequest.redirectUri
+    ) {
+      logger.warn(
+        {
+          authCodeRedirect: authCodeParams.redirectUri,
+          tokenRequestRedirect: parsedTokenRequest.tokenRequest.redirectUri,
+        },
+        "Mismatch in redirect uri between auth code params and token request"
+      );
+      throw new TokenRequestError({
+        errorCode: "invalid_grant",
+        errorDescription: "Invalid grant",
+        httpStatusCode: 400,
+      });
+    }
+
+    const accessToken = await createAccessToken(authCodeParams.scopes);
+    const idToken = await createIdToken(authCodeParams, accessToken);
+
+    res.status(200).json({
+      access_token: accessToken,
+      token_type: "Bearer",
+      expires_in: 3600,
+      id_token: idToken,
+    });
+
+    return;
+  } catch (error) {
+    logger.error("Token Request Error: " + (error as Error).message);
+
+    if (error instanceof TokenRequestError) {
+      handleTokenRequestError(error, res);
+      return;
+    } else if (error instanceof ParseRequestError) {
+      res.status(400).json({
+        error: "invalid_request",
+        error_description: "Invalid private_key_jwt",
+      });
+      return;
+    } else {
+      res.status(500).json({
+        error: "server_error",
+      });
+      return;
+    }
+  }
+};
+
+const handleTokenRequestError = (error: TokenRequestError, res: Response) => {
+  res.status(error.httpStatusCode).json({
+    error: error.errorCode,
+    error_description: error.errorDescription,
+  });
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -172,7 +172,9 @@ CQIDAQAB
     this.responseConfiguration.phoneNumberVerified = phoneNumberVerified;
   }
 
-  public getAuthCodeRequestParams(authCode: string): AuthRequestParameters {
+  public getAuthCodeRequestParams(
+    authCode: string
+  ): AuthRequestParameters | undefined {
     return this.authCodeRequestParamsStore[authCode];
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,19 @@
+export const ISSUER_VALUE = "https://oidc.account.gov.uk";
+export const EXPECTED_PRIVATE_KEY_JWT_AUDIENCE =
+  "https://oidc.account.gov.uk/token";
+export const TRUSTMARK_URL = "https://oidc.account.gov.uk/trustmark";
+export const ACCESS_TOKEN_EXPIRY = 180; //3 Minutes
+export const ID_TOKEN_EXPIRY = 120; //2  Minutes
+//We currently use a static session id for the access and id tokens.
+//We can fix this later
+export const SESSION_ID = "50a9041b5d57cb53632a0e9259864b71";
+
+//This is not a secret, this is the simulator's provider key used to sign tokens
+export const RSA_PRIVATE_TOKEN_SIGNING_KEY =
+  "-----BEGIN PRIVATE KEY-----MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDCwNMZ2+cMY7xoSiiEAR8IBpL/uN5u7gM0mkc47Q9W+CDHpKfmSRmZZao6/lE0Y7wI5HcXBTkYf2gyPSK4SWa0uE+EiyHyfx94LcItof+aNjSgckJ7Yv4taG0ipOfhHpZ3x9kJ51KZmdoTmpbMtxIEqUPQCi6gXulOjWQFIoPa7rJMRrTUInfMAYyrScvZvYu2iwrZZhyLkpr6NQXVDbSqU5HV9iTBDrJNwdgcqMX1CrZIMXCXKD4Ji2E2Ki6Xl3xMWDmQVudAkwk7I8FCfRdXnxTZd2K0Nr1Y3Bc1kaFqCsexwmFqUP0aqDNYHmMctBCPm9Z3j7GzqPzUPp0udY6HAgMBAAECggEAVJVpuffrg9KHYCYhLZ/NCe/NBVqV5MjjxINi/oLbIDMZDYxiTZ6fCyQACKouu5m7b4NGg82FbDHdn8A0paRfgorwIklJP6hdkxUQmkAbIq97MNofLLakXTVW/O5xNTFTOYenKGl60vJiqBQCfbvfC/410ROzB3zhSHgZIi/I45r4/EDQuKXcSBfszKDQ8+uVhXHv0Ck7ny+fEXxgfgm7v0PEwlHvBBbig7fAdxBefwdgaXQMRtDiJBbjIYTm8OpynjCENd3jRmuR2qAErt1mCEDg/OaHzWV+LDffOg1DBACjzIlJ5ltE+VPRy17x6lj1KOrgUGRLqsLAst9y5f/bxQKBgQDkjSFEBXymIZBIAwCNdGnqMMqmotNB5hjxupbRL+atvsQ3wabPpp8rL3aRrjVydDPHmLS6iQx6C8tV0tFUP6lkRJ17nmqcw8+kyJZ7q0QfwoG+Vegm3lqlcnnkJm9YUe2uWeZpCnjlzlaDVNCK+MMZ2lZGb1NflT34VvWqelygnQKBgQDaJJBpJQni+HoQtSs/g3AsgY+K+MoEHksqG9TabWWStFv7idLMgKhWWiIQJmRrCpseU/8N5DjaPPEL0hSiS28VzGdsNXU37O7ZSnr3YVIms1bzgFABF4bOr+SoVQ2d5DndDztsgNdrARGAPoOFsvEt80DdncS6NKEfBBgk8b6IcwKBgQCtfUQHMnMQWOIBB+ZfekL79tWd8HOUzmmY9R6O5GGi+fBQsrtBXSXtzjWfGDKSEwtLM+vcvTOvYUyUdVdZMIoRBtTUhcg//5Obbnhsn/Eyep+qL+PtvVPpyyAjw9k5nddiRfPVQJHNP/gD8VnsZDEVatua097h65QC81/AbOnrMQKBgD9VDEQqh7NIto+xOYwoCeIx/022q1gEv4fLKsH7rtin2mit+/B5jeX8JxWPP+o/2wc0FcGft83MkaL/7BOuWOL4RDKLVqvU8wdM82Rs8d/gg2cQoqmeffn14Snp/5kOkKoYaQU4ZtJfLgiQnbisWg8gJ33v9xSkgP6zPptDQDD3AoGBAKEqpxhCf7jpae5t1KJUupHjrB2Lb0bV7p8U7FiX9NObmyWuVMBRWYYEBe1QkXlmsOM4EMlvaUJZYXPvB52w5mT2FX6Ve6bqpY7T0VxbLBKwAIXTigxvUZuIfkXbhreR/PPCjrjifQr0SAZZjedmykg1vHJB4wIHJNOzE+GsmhgO-----END PRIVATE KEY-----";
+export const RSA_KEY_ID = "7334b718-3f29-44ef-8b65-e266a17daea5";
+
+//This is not a secret, this is the simulator's provider key used to sign tokens
+export const EC_PRIVATE_TOKEN_SIGNING_KEY =
+  "-----BEGIN PRIVATE KEY-----MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgJx+BhLSXqIdFrPhFmAkifXysPRgVHCmyKi8DqMHH1XihRANCAAT/AhlQkClTY+FuaQUEoGvTMPaJq5IQY0HbItiGtjLEu18alBOIfHfW8BgjynlTmYvsdJ0+sJ80r14YDsbPBjNZ-----END PRIVATE KEY-----";
+export const EC_KEY_ID = "b9162667-e025-4d93-8c5b-e538e6c792ac";

--- a/src/errors/parse-request-error.ts
+++ b/src/errors/parse-request-error.ts
@@ -1,0 +1,6 @@
+export class ParseRequestError extends Error {
+  constructor(message: string) {
+    super();
+    this.message = message;
+  }
+}

--- a/src/errors/token-request-error.ts
+++ b/src/errors/token-request-error.ts
@@ -1,0 +1,17 @@
+export class TokenRequestError extends Error {
+  public errorCode: string;
+  public errorDescription: string;
+  public httpStatusCode: number;
+
+  constructor(errorOptions: {
+    errorCode: string;
+    errorDescription: string;
+    httpStatusCode: 400 | 401 | 403 | 500 | 502;
+  }) {
+    super();
+    this.message = `${errorOptions.errorCode}: ${errorOptions.errorDescription}`;
+    this.errorCode = errorOptions.errorCode;
+    this.errorDescription = errorOptions.errorDescription;
+    this.httpStatusCode = errorOptions.httpStatusCode;
+  }
+}

--- a/src/parse/parse-token-request.ts
+++ b/src/parse/parse-token-request.ts
@@ -1,0 +1,316 @@
+import { ParseRequestError } from "../errors/parse-request-error";
+import { TokenRequestError } from "../errors/token-request-error";
+import { logger } from "../logger";
+import { TokenRequest } from "../types/token-request";
+import { PrivateKeyJwt } from "../types/private-key-jwt";
+import {
+  decodeJwt,
+  decodeProtectedHeader,
+  importSPKI,
+  jwtVerify,
+  errors,
+  JWTPayload,
+} from "jose";
+import { Config } from "../config";
+import { EXPECTED_PRIVATE_KEY_JWT_AUDIENCE } from "../constants";
+
+export const parseTokenRequest = async (
+  tokenRequestBody: Record<string, string>,
+  config: Config
+): Promise<{
+  tokenRequest: TokenRequest;
+  clientAssertion: PrivateKeyJwt;
+}> => {
+  const clientPublicKey = config.getPublicKey();
+  const tokenSigningAlgorithm = config.getIdTokenSigningAlgorithm();
+
+  if (!tokenRequestBody.grant_type) {
+    logger.error("Token Request missing grant_type");
+    throw new TokenRequestError({
+      errorCode: "invalid_request",
+      errorDescription: "Request is missing grant_type parameter",
+      httpStatusCode: 400,
+    });
+  }
+
+  if (tokenRequestBody.grant_type !== "authorization_code") {
+    logger.error(
+      { grant_type: tokenRequestBody.grant_type },
+      "Token request grant_type is invalid "
+    );
+    throw new TokenRequestError({
+      errorCode: "unsupported_grant_type",
+      errorDescription: "Unsupported grant type",
+      httpStatusCode: 400,
+    });
+  }
+
+  if (!tokenRequestBody.redirect_uri) {
+    logger.error("Token request is missing redirect URI");
+    throw new TokenRequestError({
+      errorCode: "invalid_request",
+      errorDescription: "Request is missing redirect_uri parameter",
+      httpStatusCode: 400,
+    });
+  }
+
+  if (!tokenRequestBody.code) {
+    logger.error("Token request is missing code");
+    throw new TokenRequestError({
+      errorCode: "invalid_request",
+      errorDescription: "Request is missing code parameter",
+      httpStatusCode: 400,
+    });
+  }
+
+  if (
+    !tokenRequestBody.client_assertion_type ||
+    !tokenRequestBody.client_assertion
+  ) {
+    throw new TokenRequestError({
+      errorCode: "invalid_request",
+      errorDescription: "Invalid token authentication method used",
+      httpStatusCode: 400,
+    });
+  }
+
+  if (
+    tokenRequestBody.client_assertion_type !==
+    "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+  ) {
+    logger.warn(
+      { client_assertion_type: tokenRequestBody.client_assertion_type },
+      "Client Auth Method is private_key_jwt but client_assertion_type is incorrect"
+    );
+
+    throw new TokenRequestError({
+      errorCode: "invalid_request",
+      errorDescription: "Invalid private_key_jwt",
+      httpStatusCode: 400,
+    });
+  }
+
+  const parsedClientAssertion = parseClientAssertion(
+    tokenRequestBody.client_assertion,
+    tokenRequestBody.client_id
+  );
+
+  if (parsedClientAssertion.clientId !== config.getClientId()) {
+    logger.warn("Invalid Client provided in private_key_jwt");
+    throw new TokenRequestError({
+      errorCode: "invalid_client",
+      errorDescription: "Client authentication failed",
+      httpStatusCode: 401,
+    });
+  }
+
+  if (isPrivateKeyJwtExpired(parsedClientAssertion.payload.exp)) {
+    logger.warn("private_key_jwt has expired");
+    throw new TokenRequestError({
+      errorCode: "invalid_grant",
+      errorDescription: "private_key_jwt has expired",
+      httpStatusCode: 400,
+    });
+  }
+
+  if (
+    (typeof parsedClientAssertion.payload.aud === "string" &&
+      parsedClientAssertion.payload.aud !==
+        EXPECTED_PRIVATE_KEY_JWT_AUDIENCE) ||
+    (Array.isArray(parsedClientAssertion.payload.aud) &&
+      !parsedClientAssertion.payload.aud.includes(
+        EXPECTED_PRIVATE_KEY_JWT_AUDIENCE
+      ))
+  ) {
+    //We need to error here to match the validation in the token handler
+    //This matches the validation here https://github.com/govuk-one-login/authentication-api/blob/dc42596ab02184f80c30f327a7dcd0f76146e619/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationService.java#L103 where the audience is validated in the client signature
+    // validation service
+    logger.warn(
+      `Invalid audience in client JWT assertion: Expected: ${EXPECTED_PRIVATE_KEY_JWT_AUDIENCE}, Received: ${parsedClientAssertion.payload.aud}`
+    );
+
+    throw new TokenRequestError({
+      errorCode: "invalid_client",
+      errorDescription: "Invalid signature in private_key_jwt",
+      httpStatusCode: 400,
+    });
+  }
+
+  if (parsedClientAssertion.payload.sub !== parsedClientAssertion.payload.iss) {
+    logger.warn(
+      {
+        iss_claim: parsedClientAssertion.payload.iss,
+        sub_claim: parsedClientAssertion.payload.sub,
+      },
+      "client_assertion iss and sub claims do not match"
+    );
+
+    throw new TokenRequestError({
+      errorCode: "invalid_client",
+      errorDescription: "Invalid signature in private_key_jwt",
+      httpStatusCode: 400,
+    });
+  }
+
+  if (
+    !(await isSignatureValid(
+      clientPublicKey,
+      tokenSigningAlgorithm,
+      parsedClientAssertion.token
+    ))
+  ) {
+    logger.warn("Could not verify signature of private_key_jwt");
+    throw new TokenRequestError({
+      errorCode: "invalid_client",
+      errorDescription: "Invalid signature in private_key_jwt",
+      httpStatusCode: 400,
+    });
+  }
+
+  return {
+    tokenRequest: {
+      grant_type: tokenRequestBody.grant_type,
+      redirectUri: tokenRequestBody.redirect_uri,
+      code: tokenRequestBody.code,
+      client_assertion: tokenRequestBody.client_assertion,
+      client_assertion_type: tokenRequestBody.client_assertion_type,
+    },
+    clientAssertion: parsedClientAssertion,
+  };
+};
+
+const parseClientAssertion = (
+  clientAssertion: string,
+  tokenRequestClientId?: string
+): PrivateKeyJwt => {
+  const jwtParts = clientAssertion.split(".");
+
+  if (jwtParts.length !== 3) {
+    throw new ParseRequestError(
+      "Invalid client_assertion JWT: Unexpected number of Base64URL parts, must be three"
+    );
+  }
+
+  let payload: JWTPayload;
+  try {
+    payload = decodeJwt(clientAssertion);
+  } catch (error) {
+    if (error instanceof errors.JWTInvalid) {
+      logger.error("Invalid JSON in client_assertion: " + error.message);
+      throw new ParseRequestError(
+        "Payload of JWS object is not a valid JSON object"
+      );
+    } else throw error;
+  }
+  const header = decodeProtectedHeader(clientAssertion);
+  const signature = jwtParts[2];
+
+  if (!signature || signature.trim().length === 0) {
+    throw new ParseRequestError(
+      "Invalid client_assertion JWT: The signature must not be empty"
+    );
+  }
+
+  if (!payload.sub) {
+    throw new ParseRequestError(
+      "Invalid client_assertion JWT: Missing subject in client JWT assertion"
+    );
+  }
+
+  if (!payload.iss) {
+    throw new ParseRequestError(
+      "Invalid client_assertion JWT: Missing issuer in client JWT assertion"
+    );
+  }
+
+  if (!payload.aud) {
+    throw new ParseRequestError(
+      "Invalid client_assertion JWT: Missing audience in client JWT assertion"
+    );
+  }
+
+  if (!payload.exp || typeof payload.exp !== "number") {
+    throw new ParseRequestError(
+      "Invalid client_assertion JWT: Missing or invalid expiry in client JWT assertion"
+    );
+  }
+
+  if (payload.nbf) {
+    //We don't care about this claim but it can be included and
+    //can cause a ParseError if the claim is invalid
+    logger.warn(
+      "nbf claim included in client JWT assertion, this claim is not needed: https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/authenticate-your-user/#create-a-jwt"
+    );
+
+    if (typeof payload.nbf !== "number") {
+      throw new ParseRequestError(
+        "Invalid client_assertion JWT: Invalid nbf claim in client JWT assertion"
+      );
+    }
+  }
+
+  if (!payload.iat) {
+    logger.warn(
+      "iat claim not included in client JWT assertion, this claim is recommended: https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/authenticate-your-user/#create-a-jwt"
+    );
+  }
+
+  if (payload.iat && typeof payload.iat !== "number") {
+    throw new ParseRequestError(
+      "Invalid client_assertion JWT: Invalid iat claim in client JWT assertion"
+    );
+  }
+
+  if (!payload.jti) {
+    logger.warn(
+      "No jti claim in client JWT assertion, this is required: https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/authenticate-your-user/#create-a-jwt"
+    );
+  }
+
+  if (!header.alg || !["RS256", "ES256"].includes(header.alg)) {
+    throw new ParseRequestError(
+      "Invalid client_assertion JWT: The client assertion JWT must be RSA or ECDSA-signed (RS256, RS384, RS512, PS256, PS384, PS512, ES256, ES384 or ES512)"
+    );
+  }
+
+  if (tokenRequestClientId && tokenRequestClientId !== payload.sub) {
+    throw new ParseRequestError(
+      "Invalid client_assertion JWT: The client identifier doesn't match the client assertion subject"
+    );
+  }
+
+  return {
+    header,
+    payload: {
+      exp: payload.exp,
+      sub: payload.sub,
+      iss: payload.iss,
+      aud: payload.aud,
+      ...(payload.jti && { jti: payload.jti }),
+      ...(payload.iat && { iat: payload.iat }),
+    },
+    signature,
+    clientId: payload.sub,
+    token: clientAssertion,
+  };
+};
+
+const isPrivateKeyJwtExpired = (exp: number): boolean => {
+  const currentTimeInSeconds = Math.floor(Date.now() / 1000);
+  return currentTimeInSeconds > exp;
+};
+
+const isSignatureValid = async (
+  publicKey: string,
+  alg: string,
+  token: string
+): Promise<boolean> => {
+  try {
+    const parsedPublicKey = await importSPKI(publicKey, alg);
+    await jwtVerify(token, parsedPublicKey);
+    return true;
+  } catch (error) {
+    logger.error("Error validating signature", error);
+    return false;
+  }
+};

--- a/src/parse/tests/parse-token-request.test.ts
+++ b/src/parse/tests/parse-token-request.test.ts
@@ -1,0 +1,854 @@
+import { exportSPKI, SignJWT } from "jose";
+import { Config } from "../../config";
+import { EXPECTED_PRIVATE_KEY_JWT_AUDIENCE } from "../../constants";
+import { ParseRequestError } from "../../errors/parse-request-error";
+import { TokenRequestError } from "../../errors/token-request-error";
+import { parseTokenRequest } from "../parse-token-request";
+import { generateKeyPairSync, randomUUID } from "crypto";
+
+const fakeClientAssertion = (
+  header: Record<string, string>,
+  payload: Record<string, unknown> | string,
+  signature = "r1Ylfhhy6VNSlhlhW1N89F3WfIGuko2rvSRWO4yK1BI"
+) =>
+  Buffer.from(JSON.stringify(header)).toString("base64url") +
+  "." +
+  Buffer.from(JSON.stringify(payload)).toString("base64url") +
+  "." +
+  signature;
+
+const config = Config.getInstance();
+const publicKeySpy = jest.spyOn(config, "getPublicKey");
+const idTokenSigningSpy = jest.spyOn(config, "getIdTokenSigningAlgorithm");
+const clientIdSpy = jest.spyOn(config, "getClientId");
+
+const rsaKeyPair = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+});
+const testTimestamp = 1723707024;
+const knownClientId = "b1a80190cf07983fca7e46375385a8ed";
+
+describe("parseTokenRequest tests", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(testTimestamp);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("throws an invalid_request error for no grant_type", async () => {
+    await expect(
+      parseTokenRequest(
+        {
+          code: "1234",
+          redirect_uri: "https://example.com/authentication-callback/",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_assertion:
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIiLCJpc3MiOiIiLCJhdWQiOiIiLCJqdGkiOiIifQ.r1Ylfhhy6VNSlhlhW1N89F3WfIGuko2rvSRWO4yK1BI",
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new TokenRequestError({
+        errorCode: "invalid_request",
+        errorDescription: "Request is missing grant_type parameter",
+        httpStatusCode: 400,
+      })
+    );
+  });
+
+  it("throws an invalid_request error when the grant_type is not authorization_code", async () => {
+    await expect(() =>
+      parseTokenRequest(
+        {
+          grant_type: "not_authorization_code",
+          code: "1234",
+          redirect_uri: "https://example.com/authentication-callback/",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_assertion:
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIiLCJpc3MiOiIiLCJhdWQiOiIiLCJqdGkiOiIifQ.r1Ylfhhy6VNSlhlhW1N89F3WfIGuko2rvSRWO4yK1BI",
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new TokenRequestError({
+        errorCode: "unsupported_grant_type",
+        errorDescription: "Unsupported grant type",
+        httpStatusCode: 400,
+      })
+    );
+  });
+
+  it("throws an invalid_request error when no redirect_uri is included", async () => {
+    await expect(() =>
+      parseTokenRequest(
+        {
+          grant_type: "authorization_code",
+          code: "1234",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_assertion:
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIiLCJpc3MiOiIiLCJhdWQiOiIiLCJqdGkiOiIifQ.r1Ylfhhy6VNSlhlhW1N89F3WfIGuko2rvSRWO4yK1BI",
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new TokenRequestError({
+        errorCode: "invalid_request",
+        errorDescription: "Request is missing redirect_uri parameter",
+        httpStatusCode: 400,
+      })
+    );
+  });
+
+  it("throws an invalid_request error when no code is included", async () => {
+    await expect(
+      parseTokenRequest(
+        {
+          grant_type: "authorization_code",
+          redirect_uri: "https://example.com/authentication-callback/",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_assertion:
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIiLCJpc3MiOiIiLCJhdWQiOiIiLCJqdGkiOiIifQ.r1Ylfhhy6VNSlhlhW1N89F3WfIGuko2rvSRWO4yK1BI",
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new TokenRequestError({
+        errorCode: "invalid_request",
+        errorDescription: "Request is missing code parameter",
+        httpStatusCode: 400,
+      })
+    );
+  });
+
+  it("throws an invalid_request error when the client_assertion_type is not included", async () => {
+    await expect(
+      parseTokenRequest(
+        {
+          grant_type: "authorization_code",
+          redirect_uri: "https://example.com/authentication-callback/",
+          code: "1234",
+          client_assertion:
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIiLCJpc3MiOiIiLCJhdWQiOiIiLCJqdGkiOiIifQ.r1Ylfhhy6VNSlhlhW1N89F3WfIGuko2rvSRWO4yK1BI",
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new TokenRequestError({
+        errorCode: "invalid_request",
+        errorDescription: "Invalid token authentication method used",
+        httpStatusCode: 400,
+      })
+    );
+  });
+
+  it("throws an invalid_request error when the client_assertion is not included", async () => {
+    await expect(() =>
+      parseTokenRequest(
+        {
+          grant_type: "authorization_code",
+          redirect_uri: "https://example.com/authentication-callback/",
+          code: "1234",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new TokenRequestError({
+        errorCode: "invalid_request",
+        errorDescription: "Invalid token authentication method used",
+        httpStatusCode: 400,
+      })
+    );
+  });
+
+  it("throws an invalid when the client_assertion_type is not urn:ietf:params:oauth:client-assertion-type:jwt-bearer", async () => {
+    await expect(() =>
+      parseTokenRequest(
+        {
+          grant_type: "authorization_code",
+          redirect_uri: "https://example.com/authentication-callback/",
+          code: "1234",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:some-other-assertion",
+          client_assertion:
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIiLCJpc3MiOiIiLCJhdWQiOiIiLCJqdGkiOiIifQ.r1Ylfhhy6VNSlhlhW1N89F3WfIGuko2rvSRWO4yK1BI",
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new TokenRequestError({
+        errorCode: "invalid_request",
+        errorDescription: "Invalid private_key_jwt",
+        httpStatusCode: 400,
+      })
+    );
+  });
+
+  it("throws an ParseRequestError for an invalid JWS in the client_assertion", async () => {
+    await expect(() =>
+      parseTokenRequest(
+        {
+          grant_type: "authorization_code",
+          code: "123456",
+          redirect_uri: "https://example.com/authentication-callback/",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_assertion: "some.invalid.jws.with.too.many.parts",
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new ParseRequestError(
+        "Invalid client_assertion JWT: " +
+          "Unexpected number of Base64URL parts, must be three"
+      )
+    );
+  });
+
+  it("throws an ParseRequestError if the payload is invalid JSON", async () => {
+    await expect(() =>
+      parseTokenRequest(
+        {
+          grant_type: "authorization_code",
+          code: "123456",
+          redirect_uri: "https://example.com/authentication-callback/",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_assertion: fakeClientAssertion(
+            {
+              alg: "RS256",
+            },
+            "NotValidJson"
+          ),
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new ParseRequestError("Payload of JWS object is not a valid JSON object")
+    );
+  });
+
+  it("throws an ParseRequestError if the signature is empty", async () => {
+    await expect(() =>
+      parseTokenRequest(
+        {
+          grant_type: "authorization_code",
+          code: "123456",
+          redirect_uri: "https://example.com/authentication-callback/",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_assertion: fakeClientAssertion(
+            {
+              alg: "RS256",
+            },
+            {
+              sub: "clientId",
+              iss: "clientId",
+              jti: "uhedr437r4gbfqq3rd43r",
+              exp: 1234567,
+              aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+            },
+            "             "
+          ),
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new ParseRequestError(
+        "Invalid client_assertion JWT: " + "The signature must not be empty"
+      )
+    );
+  });
+
+  it("throws an ParseRequestError if there is no sub claim in the client_assertion", async () => {
+    await expect(() =>
+      parseTokenRequest(
+        {
+          grant_type: "authorization_code",
+          code: "123456",
+          redirect_uri: "https://example.com/authentication-callback/",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_assertion: fakeClientAssertion(
+            {
+              alg: "RS256",
+            },
+            {
+              iss: "clientId",
+              jti: "uhedr437r4gbfqq3rd43r",
+              exp: 1234567,
+              aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+            }
+          ),
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new ParseRequestError(
+        "Invalid client_assertion JWT: " +
+          "Missing subject in client JWT assertion"
+      )
+    );
+  });
+
+  it("throws an ParseRequestError if there is no issuer in the client_assertion", async () => {
+    await expect(() =>
+      parseTokenRequest(
+        {
+          grant_type: "authorization_code",
+          code: "123456",
+          redirect_uri: "https://example.com/authentication-callback/",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_assertion: fakeClientAssertion(
+            {
+              alg: "RS256",
+            },
+            {
+              sub: "clientId",
+              jti: "uhedr437r4gbfqq3rd43r",
+              exp: 1234567,
+              aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+            }
+          ),
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new ParseRequestError(
+        "Invalid client_assertion JWT: " +
+          "Missing issuer in client JWT assertion"
+      )
+    );
+  });
+
+  it("throws an ParseRequestError if there is no aud in the client_assertion", async () => {
+    await expect(() =>
+      parseTokenRequest(
+        {
+          grant_type: "authorization_code",
+          code: "123456",
+          redirect_uri: "https://example.com/authentication-callback/",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_assertion: fakeClientAssertion(
+            {
+              alg: "RS256",
+            },
+            {
+              sub: "clientId",
+              iss: "clientId",
+              jti: "uhedr437r4gbfqq3rd43r",
+              exp: 1234567,
+            }
+          ),
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new ParseRequestError(
+        "Invalid client_assertion JWT: " +
+          "Missing audience in client JWT assertion"
+      )
+    );
+  });
+
+  it("throws an ParseRequestError if there is no exp in the client_assertion", async () => {
+    await expect(() =>
+      parseTokenRequest(
+        {
+          grant_type: "authorization_code",
+          code: "123456",
+          redirect_uri: "https://example.com/authentication-callback/",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_assertion: fakeClientAssertion(
+            {
+              alg: "RS256",
+            },
+            {
+              sub: "clientId",
+              iss: "clientId",
+              jti: "uhedr437r4gbfqq3rd43r",
+              aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+            }
+          ),
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new ParseRequestError(
+        "Invalid client_assertion JWT: " +
+          "Missing or invalid expiry in client JWT assertion"
+      )
+    );
+  });
+
+  it("throws an ParseRequestError if the exp is invalid the client_assertion", async () => {
+    await expect(() =>
+      parseTokenRequest(
+        {
+          grant_type: "authorization_code",
+          code: "123456",
+          redirect_uri: "https://example.com/authentication-callback/",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_assertion: fakeClientAssertion(
+            {
+              alg: "RS256",
+            },
+            {
+              sub: "clientId",
+              iss: "clientId",
+              jti: "uhedr437r4gbfqq3rd43r",
+              aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+              exp: "notANumber",
+            }
+          ),
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new ParseRequestError(
+        "Invalid client_assertion JWT: " +
+          "Missing or invalid expiry in client JWT assertion"
+      )
+    );
+  });
+
+  it("throws an ParseRequestError if the nbf claim is invalid the client_assertion", async () => {
+    await expect(() =>
+      parseTokenRequest(
+        {
+          grant_type: "authorization_code",
+          code: "123456",
+          redirect_uri: "https://example.com/authentication-callback/",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_assertion: fakeClientAssertion(
+            {
+              alg: "RS256",
+            },
+            {
+              sub: "clientId",
+              iss: "clientId",
+              jti: "uhedr437r4gbfqq3rd43r",
+              aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+              exp: 12345678,
+              nbf: "notANumber",
+            }
+          ),
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new ParseRequestError(
+        "Invalid client_assertion JWT: " +
+          "Invalid nbf claim in client JWT assertion"
+      )
+    );
+  });
+
+  it("throws an ParseRequestError if the nbf claim is invalid the client_assertion", async () => {
+    await expect(() =>
+      parseTokenRequest(
+        {
+          grant_type: "authorization_code",
+          code: "123456",
+          redirect_uri: "https://example.com/authentication-callback/",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_assertion: fakeClientAssertion(
+            {
+              alg: "RS256",
+            },
+            {
+              sub: "clientId",
+              iss: "clientId",
+              jti: "uhedr437r4gbfqq3rd43r",
+              aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+              exp: 12345678,
+              iat: "notANumber",
+            }
+          ),
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new ParseRequestError(
+        "Invalid client_assertion JWT: " +
+          "Invalid iat claim in client JWT assertion"
+      )
+    );
+  });
+
+  it("throws an ParseRequestError if there is no alg in the header", async () => {
+    await expect(() =>
+      parseTokenRequest(
+        {
+          grant_type: "authorization_code",
+          code: "123456",
+          redirect_uri: "https://example.com/authentication-callback/",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_assertion: fakeClientAssertion(
+            {},
+            {
+              sub: "clientId",
+              iss: "clientId",
+              jti: "uhedr437r4gbfqq3rd43r",
+              exp: 1234567,
+              aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+            }
+          ),
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new ParseRequestError(
+        "Invalid client_assertion JWT: " +
+          "The client assertion JWT must be RSA or ECDSA-signed (RS256, RS384, RS512, PS256, PS384, PS512, ES256, ES384 or ES512)"
+      )
+    );
+  });
+
+  it("throws an ParseRequestError if the alg in the header is not RS256 or ES256", async () => {
+    await expect(() =>
+      parseTokenRequest(
+        {
+          grant_type: "authorization_code",
+          code: "123456",
+          redirect_uri: "https://example.com/authentication-callback/",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_assertion: fakeClientAssertion(
+            {
+              alg: "HS256",
+            },
+            {
+              sub: "clientId",
+              iss: "clientId",
+              jti: "uhedr437r4gbfqq3rd43r",
+              exp: 1234567,
+              aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+            }
+          ),
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new ParseRequestError(
+        "Invalid client_assertion JWT: " +
+          "The client assertion JWT must be RSA or ECDSA-signed (RS256, RS384, RS512, PS256, PS384, PS512, ES256, ES384 or ES512)"
+      )
+    );
+  });
+
+  it("throws an error if the token request includes a top-level client_id which does not match the sub in the client_assertion", async () => {
+    await expect(
+      parseTokenRequest(
+        {
+          grant_type: "authorization_code",
+          code: "123456",
+          redirect_uri: "https://example.com/authentication-callback/",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_id: "someInvalidClient",
+
+          client_assertion: fakeClientAssertion(
+            {
+              alg: "RS256",
+            },
+            {
+              sub: "clientId",
+              iss: "clientId",
+              jti: "uhedr437r4gbfqq3rd43r",
+              exp: 1234567,
+              aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+            }
+          ),
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new ParseRequestError(
+        "Invalid client_assertion JWT: " +
+          "The client identifier doesn't match the client assertion subject"
+      )
+    );
+  });
+
+  it("throws an invalid_client error if the client_id from the client_assertion does not match the config", async () => {
+    clientIdSpy.mockReturnValue(knownClientId);
+    const publicKey = await exportSPKI(rsaKeyPair.publicKey);
+    publicKeySpy.mockReturnValue(publicKey);
+    idTokenSigningSpy.mockReturnValue("RS256");
+
+    const clientId = "clientId";
+    const header = {
+      alg: "RS256",
+    };
+    const payload = {
+      sub: clientId,
+      exp: Math.floor(testTimestamp / 1000) + 300,
+      iss: clientId,
+      aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+      jti: randomUUID(),
+    };
+
+    const client_assertion = await new SignJWT(payload)
+      .setProtectedHeader(header)
+      .sign(rsaKeyPair.privateKey);
+
+    await expect(
+      parseTokenRequest(
+        {
+          grant_type: "authorization_code",
+          code: "123456",
+          redirect_uri: "https://example.com/authentication-callback/",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_assertion,
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new TokenRequestError({
+        errorCode: "invalid_client",
+        errorDescription: "Client authentication failed",
+        httpStatusCode: 401,
+      })
+    );
+  });
+
+  it("throws an invalid_grant error for an expired client_assertion", async () => {
+    clientIdSpy.mockReturnValue(knownClientId);
+    const publicKey = await exportSPKI(rsaKeyPair.publicKey);
+    publicKeySpy.mockReturnValue(publicKey);
+    idTokenSigningSpy.mockReturnValue("RS256");
+
+    const header = {
+      alg: "RS256",
+    };
+    const payload = {
+      sub: knownClientId,
+      exp: Math.floor(testTimestamp / 1000) - 3600,
+      iss: knownClientId,
+      aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+      jti: randomUUID(),
+    };
+
+    const clientAssertion = await new SignJWT(payload)
+      .setProtectedHeader(header)
+      .sign(rsaKeyPair.privateKey);
+
+    await expect(
+      parseTokenRequest(
+        {
+          grant_type: "authorization_code",
+          code: "123456",
+          redirect_uri: "https://example.com/authentication-callback/",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_assertion: clientAssertion,
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new TokenRequestError({
+        errorCode: "invalid_grant",
+        errorDescription: "private_key_jwt has expired",
+        httpStatusCode: 400,
+      })
+    );
+  });
+
+  it("throws an invalid_client error if the client_assertion aud is not the expected token endpoint", async () => {
+    clientIdSpy.mockReturnValue(knownClientId);
+    const publicKey = await exportSPKI(rsaKeyPair.publicKey);
+    publicKeySpy.mockReturnValue(publicKey);
+    idTokenSigningSpy.mockReturnValue("RS256");
+
+    const header = {
+      alg: "RS256",
+    };
+    const payload = {
+      sub: knownClientId,
+      exp: Math.floor(testTimestamp / 1000) + 300,
+      iss: knownClientId,
+      aud: "https://identity-provider.example.com/token",
+      jti: randomUUID(),
+    };
+
+    const client_assertion = await new SignJWT(payload)
+      .setProtectedHeader(header)
+      .sign(rsaKeyPair.privateKey);
+
+    await expect(
+      parseTokenRequest(
+        {
+          grant_type: "authorization_code",
+          code: "123456",
+          redirect_uri: "https://example.com/authentication-callback/",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_assertion,
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new TokenRequestError({
+        errorCode: "invalid_client",
+        errorDescription: "Invalid signature in private_key_jwt",
+        httpStatusCode: 400,
+      })
+    );
+  });
+
+  it("throws an invalid_client error if the client_assertion iss and sub claims do not match", async () => {
+    clientIdSpy.mockReturnValue(knownClientId);
+    const publicKey = await exportSPKI(rsaKeyPair.publicKey);
+    publicKeySpy.mockReturnValue(publicKey);
+    idTokenSigningSpy.mockReturnValue("RS256");
+
+    const header = {
+      alg: "RS256",
+    };
+    const payload = {
+      sub: knownClientId,
+      exp: Math.floor(testTimestamp / 1000) + 300,
+      iss: "notTheSameClientId",
+      aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+      jti: randomUUID(),
+    };
+
+    const client_assertion = await new SignJWT(payload)
+      .setProtectedHeader(header)
+      .sign(rsaKeyPair.privateKey);
+
+    await expect(
+      parseTokenRequest(
+        {
+          grant_type: "authorization_code",
+          code: "123456",
+          redirect_uri: "https://example.com/authentication-callback/",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_assertion,
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new TokenRequestError({
+        errorCode: "invalid_client",
+        errorDescription: "Invalid signature in private_key_jwt",
+        httpStatusCode: 400,
+      })
+    );
+  });
+
+  it("throws an invalid_client signature error if the signature cannot be validated", async () => {
+    clientIdSpy.mockReturnValue(knownClientId);
+    const publicKey = await exportSPKI(rsaKeyPair.publicKey);
+    publicKeySpy.mockReturnValue(publicKey);
+    idTokenSigningSpy.mockReturnValue("RS256");
+
+    const header = {
+      alg: "RS256",
+    };
+    const payload = {
+      sub: knownClientId,
+      exp: Math.floor(testTimestamp / 1000) + 300,
+      iss: knownClientId,
+      aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+      jti: randomUUID(),
+    };
+
+    const clientAssertion = await new SignJWT(payload)
+      .setProtectedHeader(header)
+      .sign(rsaKeyPair.privateKey);
+
+    const clientAssertionInvalid = clientAssertion.split(".");
+
+    clientAssertionInvalid[2] = "someInvalidSignature";
+
+    await expect(
+      parseTokenRequest(
+        {
+          grant_type: "authorization_code",
+          code: "123456",
+          redirect_uri: "https://example.com/authentication-callback/",
+          client_assertion_type:
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+          client_assertion: clientAssertionInvalid.join("."),
+        },
+        config
+      )
+    ).rejects.toThrow(
+      new TokenRequestError({
+        errorCode: "invalid_client",
+        errorDescription: "Invalid signature in private_key_jwt",
+        httpStatusCode: 400,
+      })
+    );
+  });
+
+  it("returns a parsed tokenRequest and clientAssertion for a valid request", async () => {
+    clientIdSpy.mockReturnValue(knownClientId);
+    const publicKey = await exportSPKI(rsaKeyPair.publicKey);
+    publicKeySpy.mockReturnValue(publicKey);
+    idTokenSigningSpy.mockReturnValue("RS256");
+
+    const header = {
+      alg: "RS256",
+    };
+    const payload = {
+      sub: knownClientId,
+      exp: Math.floor(testTimestamp / 1000) + 300,
+      iss: knownClientId,
+      aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+      jti: randomUUID(),
+    };
+
+    const clientAssertion = await new SignJWT(payload)
+      .setProtectedHeader(header)
+      .sign(rsaKeyPair.privateKey);
+
+    const tokenRequest = {
+      grant_type: "authorization_code",
+      code: "123456",
+      redirect_uri: "https://example.com/authentication-callback/",
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      client_assertion: clientAssertion,
+    };
+
+    const parsedTokenRequest = await parseTokenRequest(tokenRequest, config);
+
+    expect(parsedTokenRequest).toStrictEqual({
+      tokenRequest: {
+        grant_type: "authorization_code",
+        code: "123456",
+        redirectUri: "https://example.com/authentication-callback/",
+        client_assertion_type:
+          "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+        client_assertion: clientAssertion,
+      },
+      clientAssertion: {
+        header,
+        payload,
+        token: clientAssertion,
+        clientId: knownClientId,
+        signature: clientAssertion.split(".")[2],
+      },
+    });
+  });
+});

--- a/src/types/access-token-claims.ts
+++ b/src/types/access-token-claims.ts
@@ -1,0 +1,10 @@
+export type AccessTokenClaims = {
+  exp: number;
+  iat: number;
+  iss: string;
+  jti: string;
+  client_id: string;
+  sub: string;
+  sid: string;
+  scope: string[];
+};

--- a/src/types/auth-request-parameters.ts
+++ b/src/types/auth-request-parameters.ts
@@ -3,4 +3,8 @@ export default interface AuthRequestParameters {
   nonce: string;
   scopes: string[];
   claims: string[];
+  vtr: {
+    credentialTrust: "Cl" | "Cl.Cm";
+    levelOfConfidence?: "P0" | "P2";
+  };
 }

--- a/src/types/id-token-claims.ts
+++ b/src/types/id-token-claims.ts
@@ -1,0 +1,12 @@
+export type IdTokenClaims = {
+  at_hash: string;
+  sub: string;
+  aud: string;
+  iss: string;
+  vot: string;
+  exp: number;
+  iat: number;
+  nonce: string;
+  vtm: string;
+  sid: string;
+};

--- a/src/types/private-key-jwt.ts
+++ b/src/types/private-key-jwt.ts
@@ -1,0 +1,19 @@
+import { JWSHeaderParameters } from "jose";
+
+export type PrivateKeyJwt = {
+  header: JWSHeaderParameters;
+  payload: ClientAssertionClaims;
+  signature: string;
+  clientId: string;
+  token: string;
+};
+
+type ClientAssertionClaims = {
+  exp: number;
+  iss: string;
+  sub: string;
+  aud: string | string[];
+  //ATO-944: Update validation to match JTI checking
+  jti?: string;
+  iat?: number;
+};

--- a/src/types/token-request.ts
+++ b/src/types/token-request.ts
@@ -1,0 +1,9 @@
+export type TokenRequest = {
+  grant_type: string;
+  code: string;
+  redirectUri: string;
+  client_assertion_type: string;
+  client_assertion: string;
+  //We do not expect RPs to add this but it may be present
+  client_id?: string;
+};

--- a/tests/integration/token.test.ts
+++ b/tests/integration/token.test.ts
@@ -1,0 +1,663 @@
+import { exportSPKI, JWTPayload, SignJWT, UnsecuredJWT } from "jose";
+import { createApp } from "../../src/app";
+import request from "supertest";
+import { generateKeyPairSync, randomBytes, randomUUID } from "crypto";
+import { Config } from "../../src/config";
+import AuthRequestParameters from "../../src/types/auth-request-parameters";
+import {
+  EC_KEY_ID,
+  EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+  ISSUER_VALUE,
+  RSA_KEY_ID,
+  SESSION_ID,
+  TRUSTMARK_URL,
+} from "../../src/constants";
+
+const TOKEN_ENDPOINT = "/token";
+
+const ecKeyPair = generateKeyPairSync("ec", {
+  namedCurve: "P-256",
+});
+
+const decodeTokenPart = (part: string): Record<string, string> =>
+  JSON.parse(Buffer.from(part, "base64url").toString());
+
+const rsaKeyPair = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+});
+
+const knownClientId = "d76db56760ceda7cab875f085c54bd35";
+const redirectUri = "https://localhost:3000/authentication-callback";
+const knownSub = "urn:fdc:gov.uk:2022:9e374b47c4ef6de6551be5f28d97f9dd";
+
+const createClientAssertionPayload = (
+  payload: Record<string, unknown>,
+  isExpired = false
+) =>
+  new UnsecuredJWT(payload)
+    .setIssuedAt(Math.floor(Date.now() / 1000))
+    .setExpirationTime(isExpired ? "-1h" : "1h")
+    .setJti(randomUUID())
+    .setAudience(EXPECTED_PRIVATE_KEY_JWT_AUDIENCE)
+    .encode()
+    .split(".")[1];
+
+const createClientAssertionHeader = (signingAlgorithm: string) =>
+  Buffer.from(JSON.stringify({ alg: signingAlgorithm })).toString("base64url");
+
+const fakeSignature = () => randomBytes(16).toString("hex");
+
+const setupClientConfig = async (
+  clientId: string,
+  signingAlgorithm: "ES256" | "RS256"
+) => {
+  process.env.CLIENT_ID = clientId;
+  process.env.REDIRECT_URLS = redirectUri;
+  process.env.SUB = knownSub;
+  if (signingAlgorithm === "ES256") {
+    const publicKey = await exportSPKI(ecKeyPair.publicKey);
+    process.env.PUBLIC_KEY = publicKey;
+    process.env.ID_TOKEN_SIGNING_ALGORITHM = signingAlgorithm;
+  } else if (signingAlgorithm === "RS256") {
+    const publicKey = await exportSPKI(rsaKeyPair.publicKey);
+    process.env.PUBLIC_KEY = publicKey;
+    process.env.ID_TOKEN_SIGNING_ALGORITHM = signingAlgorithm;
+  }
+  Config.resetInstance();
+};
+
+describe("/token endpoint tests, invalid request", () => {
+  it("returns an invalid_request error for missing grant_type", async () => {
+    const app = await createApp();
+    const response = await request(app).post(TOKEN_ENDPOINT).send({
+      code: "123456",
+      redirect_uri: "http://localhost:8080/authorization-code/callback",
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      client_assertion:
+        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIiLCJpc3MiOiIiLCJhdWQiOiIiLCJqdGkiOiIifQ.r1Ylfhhy6VNSlhlhW1N89F3WfIGuko2rvSRWO4yK1BI",
+    });
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toStrictEqual({
+      error: "invalid_request",
+      error_description: "Request is missing grant_type parameter",
+    });
+  });
+
+  it("returns an invalid_request error when grant_type is not authorization_code", async () => {
+    const app = await createApp();
+    const response = await request(app).post(TOKEN_ENDPOINT).send({
+      grant_type: "not_authorization_code",
+      code: "123456",
+      redirect_uri: "http://localhost:8080/authorization-code/callback",
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      client_assertion:
+        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIiLCJpc3MiOiIiLCJhdWQiOiIiLCJqdGkiOiIifQ.r1Ylfhhy6VNSlhlhW1N89F3WfIGuko2rvSRWO4yK1BI",
+    });
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toStrictEqual({
+      error: "unsupported_grant_type",
+      error_description: "Unsupported grant type",
+    });
+  });
+
+  it("returns an invalid_request no redirect_uri is included", async () => {
+    const app = await createApp();
+    const response = await request(app).post(TOKEN_ENDPOINT).send({
+      grant_type: "authorization_code",
+      code: "123456",
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      client_assertion:
+        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIiLCJpc3MiOiIiLCJhdWQiOiIiLCJqdGkiOiIifQ.r1Ylfhhy6VNSlhlhW1N89F3WfIGuko2rvSRWO4yK1BI",
+    });
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toStrictEqual({
+      error: "invalid_request",
+      error_description: "Request is missing redirect_uri parameter",
+    });
+  });
+
+  it("returns an invalid_request when no auth_code is included", async () => {
+    const app = await createApp();
+    const response = await request(app).post(TOKEN_ENDPOINT).send({
+      grant_type: "authorization_code",
+      redirect_uri: "http://localhost:8080/authorization-code/callback",
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      client_assertion:
+        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIiLCJpc3MiOiIiLCJhdWQiOiIiLCJqdGkiOiIifQ.r1Ylfhhy6VNSlhlhW1N89F3WfIGuko2rvSRWO4yK1BI",
+    });
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toStrictEqual({
+      error: "invalid_request",
+      error_description: "Request is missing code parameter",
+    });
+  });
+
+  it("returns an invalid_request when the client_assertion_type is not included", async () => {
+    const app = await createApp();
+    const response = await request(app).post(TOKEN_ENDPOINT).send({
+      grant_type: "authorization_code",
+      code: "123456",
+      redirect_uri: "http://localhost:8080/authorization-code/callback",
+      client_assertion:
+        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIiLCJpc3MiOiIiLCJhdWQiOiIiLCJqdGkiOiIifQ.r1Ylfhhy6VNSlhlhW1N89F3WfIGuko2rvSRWO4yK1BI",
+    });
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toStrictEqual({
+      error: "invalid_request",
+      error_description: "Invalid token authentication method used",
+    });
+  });
+
+  it("returns an invalid_request when the client_assertion is not included", async () => {
+    const app = await createApp();
+    const response = await request(app).post(TOKEN_ENDPOINT).send({
+      grant_type: "authorization_code",
+      code: "123456",
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      redirect_uri: "http://localhost:8080/authorization-code/callback",
+    });
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toStrictEqual({
+      error: "invalid_request",
+      error_description: "Invalid token authentication method used",
+    });
+  });
+
+  it("returns an invalid_request when the client_assertion is not included", async () => {
+    const app = await createApp();
+    const response = await request(app).post(TOKEN_ENDPOINT).send({
+      grant_type: "authorization_code",
+      code: "123456",
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      redirect_uri: "http://localhost:8080/authorization-code/callback",
+    });
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toStrictEqual({
+      error: "invalid_request",
+      error_description: "Invalid token authentication method used",
+    });
+  });
+
+  it("returns an invalid_request when the client_assertion_type is not included", async () => {
+    const app = await createApp();
+    const response = await request(app).post(TOKEN_ENDPOINT).send({
+      grant_type: "authorization_code",
+      code: "123456",
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer-invalid",
+      redirect_uri: "http://localhost:8080/authorization-code/callback",
+      client_assertion:
+        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIiLCJpc3MiOiIiLCJhdWQiOiIiLCJqdGkiOiIifQ.r1Ylfhhy6VNSlhlhW1N89F3WfIGuko2rvSRWO4yK1BI",
+    });
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toStrictEqual({
+      error: "invalid_request",
+      error_description: "Invalid private_key_jwt",
+    });
+  });
+});
+
+describe("/token endpoint tests, invalid client assertion", () => {
+  it("returns an invalid_request if client_assertion is missing iss", async () => {
+    await setupClientConfig(knownClientId, "ES256");
+
+    const clientAssertion =
+      createClientAssertionHeader("ES256") +
+      "." +
+      createClientAssertionPayload({
+        sub: knownClientId,
+        aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+      }) +
+      "." +
+      fakeSignature();
+
+    const app = await createApp();
+    const response = await request(app).post(TOKEN_ENDPOINT).send({
+      grant_type: "authorization_code",
+      code: "123456",
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      redirect_uri: redirectUri,
+      client_assertion: clientAssertion,
+    });
+    expect(response.status).toEqual(400);
+    expect(response.body).toStrictEqual({
+      error: "invalid_request",
+      error_description: "Invalid private_key_jwt",
+    });
+  });
+
+  it("returns an invalid_request if client_assertion is missing sub", async () => {
+    await setupClientConfig(knownClientId, "ES256");
+
+    const clientAssertion =
+      createClientAssertionHeader("ES256") +
+      "." +
+      createClientAssertionPayload({
+        iss: knownClientId,
+        aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+      }) +
+      "." +
+      fakeSignature();
+
+    const app = await createApp();
+    const response = await request(app).post(TOKEN_ENDPOINT).send({
+      grant_type: "authorization_code",
+      code: "123456",
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      redirect_uri: redirectUri,
+      client_assertion: clientAssertion,
+    });
+    expect(response.status).toEqual(400);
+    expect(response.body).toStrictEqual({
+      error: "invalid_request",
+      error_description: "Invalid private_key_jwt",
+    });
+  });
+
+  it("returns an invalid_request if signing alg in header is not ES256 or RS256", async () => {
+    await setupClientConfig(knownClientId, "ES256");
+
+    const clientAssertion =
+      createClientAssertionHeader("HS256") +
+      "." +
+      createClientAssertionPayload({
+        iss: knownClientId,
+        sub: knownClientId,
+        aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+      }) +
+      "." +
+      fakeSignature();
+
+    const app = await createApp();
+    const response = await request(app).post(TOKEN_ENDPOINT).send({
+      grant_type: "authorization_code",
+      code: "123456",
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      redirect_uri: redirectUri,
+      client_assertion: clientAssertion,
+    });
+    expect(response.status).toEqual(400);
+    expect(response.body).toStrictEqual({
+      error: "invalid_request",
+      error_description: "Invalid private_key_jwt",
+    });
+  });
+
+  it("returns an invalid_client for an unknown client_id", async () => {
+    await setupClientConfig(randomUUID(), "ES256");
+
+    const clientAssertion =
+      createClientAssertionHeader("ES256") +
+      "." +
+      createClientAssertionPayload({
+        sub: knownClientId,
+        iss: knownClientId,
+        aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+      }) +
+      "." +
+      fakeSignature();
+
+    const app = await createApp();
+    const response = await request(app).post(TOKEN_ENDPOINT).send({
+      grant_type: "authorization_code",
+      code: "123456",
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      redirect_uri: redirectUri,
+      client_assertion: clientAssertion,
+    });
+    expect(response.status).toEqual(401);
+    expect(response.body).toStrictEqual({
+      error: "invalid_client",
+      error_description: "Client authentication failed",
+    });
+  });
+
+  it("returns an invalid_grant for an expired client assertion ", async () => {
+    await setupClientConfig(knownClientId, "ES256");
+
+    const clientAssertion =
+      createClientAssertionHeader("ES256") +
+      "." +
+      createClientAssertionPayload(
+        {
+          iss: knownClientId,
+          sub: knownClientId,
+          aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+        },
+        true
+      ) +
+      "." +
+      fakeSignature();
+
+    const app = await createApp();
+    const response = await request(app).post(TOKEN_ENDPOINT).send({
+      grant_type: "authorization_code",
+      code: "123456",
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      redirect_uri: redirectUri,
+      client_assertion: clientAssertion,
+    });
+    expect(response.status).toEqual(400);
+    expect(response.body).toStrictEqual({
+      error: "invalid_grant",
+      error_description: "private_key_jwt has expired",
+    });
+  });
+
+  it("returns an invalid_client for an invalid signature", async () => {
+    await setupClientConfig(knownClientId, "ES256");
+
+    const clientAssertion =
+      createClientAssertionHeader("ES256") +
+      "." +
+      createClientAssertionPayload({
+        iss: knownClientId,
+        sub: knownClientId,
+        aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+      }) +
+      "." +
+      fakeSignature();
+
+    const app = await createApp();
+    const response = await request(app).post(TOKEN_ENDPOINT).send({
+      grant_type: "authorization_code",
+      code: "123456",
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      redirect_uri: redirectUri,
+      client_assertion: clientAssertion,
+    });
+    expect(response.status).toEqual(400);
+    expect(response.body).toStrictEqual({
+      error: "invalid_client",
+      error_description: "Invalid signature in private_key_jwt",
+    });
+  });
+
+  it("returns an invalid signature for an unknown audience in client_assertion", async () => {
+    await setupClientConfig(knownClientId, "ES256");
+
+    jest
+      .spyOn(Config.getInstance(), "getAuthCodeRequestParams")
+      .mockReturnValue(undefined);
+
+    const clientAssertion =
+      createClientAssertionHeader("ES256") +
+      "." +
+      createClientAssertionPayload({
+        iss: knownClientId,
+        sub: knownClientId,
+        aud: "https://identity-provider.example.com/token",
+        jti: randomUUID(),
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      }) +
+      "." +
+      fakeSignature();
+
+    const app = await createApp();
+    const response = await request(app).post(TOKEN_ENDPOINT).send({
+      grant_type: "authorization_code",
+      code: randomUUID(),
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      redirect_uri: redirectUri,
+      client_assertion: clientAssertion,
+    });
+    expect(response.status).toEqual(400);
+    expect(response.body).toStrictEqual({
+      error: "invalid_client",
+      error_description: "Invalid signature in private_key_jwt",
+    });
+  });
+});
+
+describe("/token endpoint valid client_assertion", () => {
+  const knownAuthCode = "aac8964a69b2c7c56c3bfcf108248fe1";
+  const redirectUriMismatchCode = "5c255ea25c063a83a5f02242103bdc9f";
+  const nonce = "bf05c36da9122a7378439924c011c51c";
+  const scopes = ["openid"];
+
+  const validAuthRequestParams: AuthRequestParameters = {
+    nonce,
+    redirectUri: redirectUri,
+    scopes,
+    claims: [],
+    vtr: {
+      credentialTrust: "Cl.Cm",
+    },
+  };
+  const redirectUriMismatchParams: AuthRequestParameters = {
+    nonce,
+    redirectUri: "https://example.com/authentication-callback-invalid/",
+    scopes,
+    claims: [],
+    vtr: {
+      credentialTrust: "Cl.Cm",
+    },
+  };
+
+  const createValidClientAssertion = async (
+    payload: JWTPayload,
+    idTokenSigningAlgorithm: "ES256" | "RS256"
+  ): Promise<string> => {
+    if (idTokenSigningAlgorithm === "ES256") {
+      return await new SignJWT(payload)
+        .setProtectedHeader({
+          alg: idTokenSigningAlgorithm,
+        })
+        .sign(ecKeyPair.privateKey);
+    } else
+      return await new SignJWT(payload)
+        .setProtectedHeader({
+          alg: idTokenSigningAlgorithm,
+        })
+        .sign(rsaKeyPair.privateKey);
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns an invalid_grant error when there are no auth request params for auth code", async () => {
+    await setupClientConfig(knownClientId, "ES256");
+
+    jest
+      .spyOn(Config.getInstance(), "getAuthCodeRequestParams")
+      .mockReturnValue(undefined);
+
+    const clientAssertion = await createValidClientAssertion(
+      {
+        iss: knownClientId,
+        sub: knownClientId,
+        aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+        jti: randomUUID(),
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      },
+      "ES256"
+    );
+
+    const app = await createApp();
+    const response = await request(app).post(TOKEN_ENDPOINT).send({
+      grant_type: "authorization_code",
+      code: randomUUID(),
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      redirect_uri: redirectUri,
+      client_assertion: clientAssertion,
+    });
+    expect(response.status).toEqual(400);
+    expect(response.body).toStrictEqual({
+      error: "invalid_grant",
+      error_description: "Invalid grant",
+    });
+  });
+
+  it("returns an invalid_grant error if the request redirect uri does not match the auth code params", async () => {
+    await setupClientConfig(knownClientId, "ES256");
+    jest
+      .spyOn(Config.getInstance(), "getAuthCodeRequestParams")
+      .mockReturnValue(redirectUriMismatchParams);
+
+    const clientAssertion = await createValidClientAssertion(
+      {
+        iss: knownClientId,
+        sub: knownClientId,
+        aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+        jti: randomUUID(),
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      },
+      "ES256"
+    );
+
+    const app = await createApp();
+    const response = await request(app).post(TOKEN_ENDPOINT).send({
+      grant_type: "authorization_code",
+      code: redirectUriMismatchCode,
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      redirect_uri: redirectUri,
+      client_assertion: clientAssertion,
+    });
+    expect(response.status).toEqual(400);
+    expect(response.body).toStrictEqual({
+      error: "invalid_grant",
+      error_description: "Invalid grant",
+    });
+  });
+
+  it("returns a valid access_token and id_token for a valid token request with a ES256 signed client assertion", async () => {
+    await setupClientConfig(knownClientId, "ES256");
+    jest
+      .spyOn(Config.getInstance(), "getAuthCodeRequestParams")
+      .mockReturnValue(validAuthRequestParams);
+
+    const clientAssertion = await createValidClientAssertion(
+      {
+        iss: knownClientId,
+        sub: knownClientId,
+        aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+        jti: randomUUID(),
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      },
+      "ES256"
+    );
+
+    const app = await createApp();
+    const response = await request(app).post(TOKEN_ENDPOINT).send({
+      grant_type: "authorization_code",
+      code: knownAuthCode,
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      redirect_uri: redirectUri,
+      client_assertion: clientAssertion,
+    });
+
+    expect(response.status).toEqual(200);
+
+    const { access_token, expires_in, id_token, token_type } = response.body;
+
+    const [accessTokenHeader, accessTokenPayload] = access_token.split(".");
+    const [idTokenHeader, idTokenPayload] = id_token.split(".");
+
+    const decodedAccessToken = decodeTokenPart(accessTokenPayload);
+    const decodedIdToken = decodeTokenPart(idTokenPayload);
+
+    expect(expires_in).toEqual(3600);
+    expect(token_type).toEqual("Bearer");
+
+    expect(decodeTokenPart(accessTokenHeader)).toStrictEqual({
+      alg: "ES256",
+      kid: EC_KEY_ID,
+    });
+    expect(decodedAccessToken.sub).toBe(knownSub);
+    expect(decodedAccessToken.client_id).toBe(knownClientId);
+    expect(decodedAccessToken.sid).toBe(SESSION_ID);
+    expect(decodedAccessToken.scope).toStrictEqual(
+      validAuthRequestParams.scopes
+    );
+
+    expect(decodeTokenPart(idTokenHeader)).toStrictEqual({
+      alg: "ES256",
+      kid: EC_KEY_ID,
+    });
+    expect(decodedIdToken.sub).toBe(knownSub);
+    expect(decodedIdToken.iss).toBe(ISSUER_VALUE);
+    expect(decodedIdToken.vtm).toBe(TRUSTMARK_URL);
+    expect(decodedIdToken.aud).toBe(knownClientId);
+    expect(decodedIdToken.sid).toBe(SESSION_ID);
+    expect(decodedIdToken.nonce).toBe(validAuthRequestParams.nonce);
+    expect(decodedIdToken.vot).toBe(validAuthRequestParams.vtr.credentialTrust);
+  });
+
+  it("returns a valid access_token and id_token for a valid token request with a RS256 signed client assertion", async () => {
+    await setupClientConfig(knownClientId, "RS256");
+    jest
+      .spyOn(Config.getInstance(), "getAuthCodeRequestParams")
+      .mockReturnValue(validAuthRequestParams);
+
+    const clientAssertion = await createValidClientAssertion(
+      {
+        iss: knownClientId,
+        sub: knownClientId,
+        aud: EXPECTED_PRIVATE_KEY_JWT_AUDIENCE,
+        jti: randomUUID(),
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      },
+      "RS256"
+    );
+
+    const app = await createApp();
+    const response = await request(app).post(TOKEN_ENDPOINT).send({
+      grant_type: "authorization_code",
+      code: knownAuthCode,
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      redirect_uri: redirectUri,
+      client_assertion: clientAssertion,
+    });
+
+    expect(response.status).toEqual(200);
+
+    const { access_token, expires_in, id_token, token_type } = response.body;
+
+    const [accessTokenHeader] = access_token.split(".");
+    const [idTokenHeader] = id_token.split(".");
+
+    expect(expires_in).toEqual(3600);
+    expect(token_type).toEqual("Bearer");
+
+    expect(decodeTokenPart(accessTokenHeader)).toStrictEqual({
+      alg: "RS256",
+      kid: RSA_KEY_ID,
+    });
+
+    expect(decodeTokenPart(idTokenHeader)).toStrictEqual({
+      alg: "RS256",
+      kid: RSA_KEY_ID,
+    });
+  });
+});


### PR DESCRIPTION
## What

- The simulator now has a `/token` endpoint. 
- This endpoint responds with a token response containing an access_token and an id_token  for a valid token request
- This includes:
   - Validating the token request has all params for a `private_key_jwt` request
   - Parsing and validating the client assertion 
   - Creating and signing the Id and Access tokens
   - Uses the Config class and the authCodeStore to get specific claim values where needed
   - Returning an `error` and `error_description` for error states


## How to review: 
- Code review commit by commit 
- Look at the tests in `tests/integration/token.test.ts` to see what the endpoint response is for a range of invalid requests
