### PR TITLE
ATO-827: Authorize endpoint

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@ import express, { Application, Express, Request, Response } from "express";
 import { configController } from "./components/config/config-controller";
 import bodyParser from "body-parser";
 import { tokenController } from "./components/token/token-controller";
+import { authoriseGetController } from "./components/authorise/authorise-get-controller";
 import { dedupeQueryParams } from "./middleware/dedupe-query-params";
 
 const createApp = (): Application => {
@@ -15,6 +16,7 @@ const createApp = (): Application => {
   app.get("/", (req: Request, res: Response) => {
     res.send("Express + TypeScript Server");
   });
+  app.get("/authorize", authoriseGetController);
 
   app.post("/config", configController);
   app.post("/token", tokenController);

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@ import express, { Application, Express, Request, Response } from "express";
 import { configController } from "./components/config/config-controller";
 import bodyParser from "body-parser";
 import { tokenController } from "./components/token/token-controller";
+import { dedupeQueryParams } from "./middleware/dedupe-query-params";
 
 const createApp = (): Application => {
   const app: Express = express();
@@ -9,6 +10,7 @@ const createApp = (): Application => {
   app.use(express.json());
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: false }));
+  app.use(dedupeQueryParams);
 
   app.get("/", (req: Request, res: Response) => {
     res.send("Express + TypeScript Server");

--- a/src/components/authorise/authorise-get-controller.ts
+++ b/src/components/authorise/authorise-get-controller.ts
@@ -1,0 +1,78 @@
+import { Request, Response } from "express";
+import { logger } from "../../logger";
+import { parseAuthQueryParams } from "../../parse/parse-auth-request-query-params";
+import { AuthoriseRequestError } from "../../errors/authorise-request-error";
+import { BadRequestError } from "../../errors/bad-request-error";
+import { ParseAuthRequestError } from "../../errors/parse-auth-request-error";
+import { Config } from "../../config";
+import { MissingParameterError } from "../../errors/missing-parameter-error";
+
+export const authoriseGetController = (req: Request, res: Response): void => {
+  const config = Config.getInstance();
+
+  try {
+    const parsedAuthRequestParams = parseAuthQueryParams(
+      //We can safely cast this type as our middleware will handle
+      //any duplicate query params
+      req.query as Record<string, string | undefined>,
+      config
+    );
+
+    const authCode = generateAuthCode();
+
+    config.addToAuthCodeRequestParamsStore(authCode, {
+      claims: parsedAuthRequestParams.claims,
+      nonce: parsedAuthRequestParams.nonce,
+      redirectUri: parsedAuthRequestParams.redirect_uri,
+      scopes: parsedAuthRequestParams.scope,
+      vtr: parsedAuthRequestParams.vtr[0],
+    });
+
+    res.redirect(
+      `${parsedAuthRequestParams.redirect_uri}?code=${authCode}&state=${parsedAuthRequestParams.state}`
+    );
+    return;
+  } catch (error) {
+    logger.error("Authorise request error: " + (error as Error).message);
+    handleRequestError(error, res, config);
+    return;
+  }
+};
+
+//static auth code
+const generateAuthCode = (): string => "c87fe9af6880180fbb73a77597395053";
+
+const handleRequestError = (
+  error: unknown,
+  res: Response,
+  config: Config
+): void => {
+  if (error instanceof AuthoriseRequestError) {
+    res.redirect(
+      `${error.redirectUri}?error=${error.errorCode}&error_description=${encodeURIComponent(error.errorDescription)}${error.state ? `&state=${error.state}` : ""}`
+    );
+  } else if (error instanceof MissingParameterError) {
+    res.status(400).send("Request is missing parameters");
+  } else if (error instanceof ParseAuthRequestError) {
+    if (
+      error.clientId !== config.getClientId() ||
+      !config.getRedirectUrls().includes(error.redirectUri as string)
+    ) {
+      logger.warn(
+        `Redirect URI ${error.redirectUri} is not valid for client: ${error.clientId}`
+      );
+      res.status(400).send("Invalid Request");
+    } else {
+      res.redirect(
+        `${error.redirectUri}?error=invalid_request&error_description=${encodeURIComponent("Invalid Request")}`
+      );
+    }
+  } else if (error instanceof BadRequestError) {
+    res.status(400).send("Invalid Request");
+  } else {
+    logger.error("Unknown error occurred: " + (error as Error).message);
+    res.status(500).json({
+      message: "Internal Server Error",
+    });
+  }
+};

--- a/src/components/authorise/tests/authorise-get-controller.test.ts
+++ b/src/components/authorise/tests/authorise-get-controller.test.ts
@@ -1,0 +1,497 @@
+import { randomUUID } from "crypto";
+import { createApp } from "../../../app";
+import request from "supertest";
+import { Config } from "../../../config";
+
+const authoriseEndpoint = "/authorize";
+const knownClientId = "43c729a8f8a8bed3441a872039d45180";
+const knownRedirectUri = "https://example.com/authentication-callback";
+const unknownRedirectUri =
+  "https://some.other.client.example.com/auth-callback";
+
+const createRequestParams = (params: Record<string, string>): string => {
+  return Object.entries(params)
+    .map(([key, val]) => `${key}=${encodeURIComponent(val)}`)
+    .join("&");
+};
+
+describe("/authorize GET controller: invalid request non-redirecting errors", () => {
+  beforeAll(() => {
+    process.env.CLIENT_ID = knownClientId;
+    process.env.REDIRECT_URLS = knownRedirectUri;
+  });
+
+  it("returns a Missing Parameters response for no query strings", async () => {
+    const app = createApp();
+    const response = await request(app).get(authoriseEndpoint);
+    expect(response.status).toBe(400);
+    expect(response.text).toBe("Request is missing parameters");
+  });
+
+  it("returns an Missing Parameters response for an no client_id", async () => {
+    const app = createApp();
+    const requestParams = createRequestParams({
+      state: "51994f8e382a5c6ffa19d2518b190696",
+    });
+    const response = await request(app).get(
+      authoriseEndpoint + "?" + requestParams
+    );
+    expect(response.status).toBe(400);
+    expect(response.text).toBe("Request is missing parameters");
+  });
+
+  it("returns an Missing Parameters response for no response_type", async () => {
+    const app = createApp();
+    const requestParams = createRequestParams({
+      client_id: knownClientId,
+    });
+    const response = await request(app).get(
+      authoriseEndpoint + "?" + requestParams
+    );
+    expect(response.status).toBe(400);
+    expect(response.text).toBe("Request is missing parameters");
+  });
+
+  it("returns invalid request for a non-oidc prompt", async () => {
+    const app = createApp();
+    const requestParams = createRequestParams({
+      client_id: knownClientId,
+      response_type: "code",
+      prompt: "login unknown",
+    });
+    const response = await request(app).get(
+      authoriseEndpoint + "?" + requestParams
+    );
+    expect(response.status).toBe(400);
+    expect(response.text).toBe("Invalid Request");
+  });
+
+  it("returns an Missing Parameters response for a no redirect uri", async () => {
+    const app = createApp();
+    const requestParams = createRequestParams({
+      client_id: knownClientId,
+      response_type: "code",
+    });
+    const response = await request(app).get(
+      authoriseEndpoint + "?" + requestParams
+    );
+    expect(response.status).toBe(400);
+    expect(response.text).toBe("Request is missing parameters");
+  });
+
+  it("returns an Missing Parameters response for a badly formatted redirect uri", async () => {
+    const app = createApp();
+    const requestParams = createRequestParams({
+      client_id: knownClientId,
+      redirect_uri: ".notaredirectURI..",
+      response_type: "code",
+    });
+    const response = await request(app).get(
+      authoriseEndpoint + "?" + requestParams
+    );
+    expect(response.status).toBe(400);
+    expect(response.text).toBe("Request is missing parameters");
+  });
+
+  it("returns an Invalid request response for non-matching redirect_uri", async () => {
+    const app = createApp();
+    const requestParams = createRequestParams({
+      client_id: knownClientId,
+      redirect_uri: unknownRedirectUri,
+      response_type: "code",
+    });
+    const response = await request(app).get(
+      authoriseEndpoint + "?" + requestParams
+    );
+    expect(response.status).toBe(400);
+    expect(response.text).toBe("Invalid Request");
+  });
+
+  it("returns an Invalid request response for an unknown client_id", async () => {
+    const app = createApp();
+    const requestParams = createRequestParams({
+      client_id: randomUUID(),
+      redirect_uri: knownRedirectUri,
+      response_type: "code",
+    });
+    const response = await request(app).get(
+      authoriseEndpoint + "?" + requestParams
+    );
+    expect(response.status).toBe(400);
+    expect(response.text).toBe("Invalid Request");
+  });
+});
+
+describe("/authorize GET controller: Invalid request, redirecting errors", () => {
+  beforeEach(() => {
+    process.env.CLIENT_ID = knownClientId;
+    process.env.REDIRECT_URLS = knownRedirectUri;
+    process.env.SCOPES = "openid,email";
+    process.env.CLAIMS = "https://vocab.account.gov.uk/v1/coreIdentityJWT";
+    process.env.CLIENT_LOCS = "P2";
+    Config.resetInstance();
+  });
+
+  it("redirects with an invalid request error response for no scope parameter", async () => {
+    const app = createApp();
+    const requestParams = createRequestParams({
+      client_id: knownClientId,
+      redirect_uri: knownRedirectUri,
+      response_type: "code",
+    });
+    const response = await request(app).get(
+      authoriseEndpoint + "?" + requestParams
+    );
+    expect(response.status).toBe(302);
+    expect(response.header.location).toBe(
+      `${knownRedirectUri}?error=invalid_request&error_description=${encodeURIComponent("Invalid Request")}`
+    );
+  });
+
+  it("redirects with an invalid request error for a scope which does not include openid ", async () => {
+    const app = createApp();
+    const requestParams = createRequestParams({
+      client_id: knownClientId,
+      redirect_uri: knownRedirectUri,
+      response_type: "code",
+      scope: "email",
+    });
+    const response = await request(app).get(
+      authoriseEndpoint + "?" + requestParams
+    );
+    expect(response.status).toBe(302);
+    expect(response.header.location).toBe(
+      `${knownRedirectUri}?error=invalid_request&error_description=${encodeURIComponent("Invalid Request")}`
+    );
+  });
+
+  it("returns 302 and redirects with an error for invalid JSON in claims", async () => {
+    const app = createApp();
+    const requestParams = createRequestParams({
+      client_id: knownClientId,
+      redirect_uri: knownRedirectUri,
+      response_type: "code",
+      scope: "openid email",
+      claims: "{{}",
+    });
+    const response = await request(app).get(
+      authoriseEndpoint + "?" + requestParams
+    );
+    expect(response.status).toBe(302);
+    expect(response.header.location).toBe(
+      `${knownRedirectUri}?error=invalid_request&error_description=${encodeURIComponent("Invalid Request")}`
+    );
+  });
+
+  it("returns 302 and redirects with an error for unknown prompt", async () => {
+    const app = createApp();
+    const requestParams = createRequestParams({
+      client_id: knownClientId,
+      redirect_uri: knownRedirectUri,
+      response_type: "code",
+      scope: "openid email",
+      prompt: "login unknown",
+    });
+    const response = await request(app).get(
+      authoriseEndpoint + "?" + requestParams
+    );
+    expect(response.status).toBe(302);
+    expect(response.header.location).toBe(
+      `${knownRedirectUri}?error=invalid_request&error_description=${encodeURIComponent("Invalid Request")}`
+    );
+  });
+
+  it("returns 302 and redirects with an error for no state", async () => {
+    const app = createApp();
+    const requestParams = createRequestParams({
+      client_id: knownClientId,
+      redirect_uri: knownRedirectUri,
+      response_type: "code",
+      scope: "openid email",
+      prompt: "login",
+    });
+    const response = await request(app).get(
+      authoriseEndpoint + "?" + requestParams
+    );
+    expect(response.status).toBe(302);
+    expect(response.header.location).toBe(
+      `${knownRedirectUri}?error=invalid_request&error_description=${encodeURIComponent("Request is missing state parameter")}`
+    );
+  });
+
+  it("returns 302 and redirects if the request includes a request_uri", async () => {
+    const state = "a7e4bfd39d3eaa57c27775744f22c5a2";
+    const app = createApp();
+    const requestParams = createRequestParams({
+      client_id: knownClientId,
+      redirect_uri: knownRedirectUri,
+      response_type: "code",
+      scope: "openid email",
+      prompt: "login",
+      state,
+      request_uri: "https:/example.com/request-uri/12345",
+    });
+    const response = await request(app).get(
+      authoriseEndpoint + "?" + requestParams
+    );
+    expect(response.status).toBe(302);
+    expect(response.header.location).toBe(
+      `${knownRedirectUri}?error=request_uri_not_supported&error_description=${encodeURIComponent("Request URI parameter not supported")}&state=${state}`
+    );
+  });
+
+  it("returns 302 and redirects if the response_type is not code", async () => {
+    const state = "a7e4bfd39d3eaa57c27775744f22c5a2";
+    const app = createApp();
+    const requestParams = createRequestParams({
+      client_id: knownClientId,
+      redirect_uri: knownRedirectUri,
+      response_type: "id_token",
+      scope: "openid email",
+      prompt: "login",
+      state,
+    });
+    const response = await request(app).get(
+      authoriseEndpoint + "?" + requestParams
+    );
+    expect(response.status).toBe(302);
+    expect(response.header.location).toBe(
+      `${knownRedirectUri}?error=unsupported_response_type&error_description=${encodeURIComponent("Unsupported response type")}&state=${state}`
+    );
+  });
+
+  it("returns 302 and redirects with an error for invalid scope", async () => {
+    const state = "a7e4bfd39d3eaa57c27775744f22c5a2";
+    const app = createApp();
+    const requestParams = createRequestParams({
+      client_id: knownClientId,
+      redirect_uri: knownRedirectUri,
+      response_type: "code",
+      scope: "openid unknown",
+      prompt: "login",
+      state,
+    });
+    const response = await request(app).get(
+      authoriseEndpoint + "?" + requestParams
+    );
+    expect(response.status).toBe(302);
+    expect(response.header.location).toBe(
+      `${knownRedirectUri}?error=invalid_scope&error_description=${encodeURIComponent("Invalid, unknown or malformed scope")}&state=${state}`
+    );
+  });
+
+  it("returns 302 and redirects with an error for unsupported scope", async () => {
+    const state = "a7e4bfd39d3eaa57c27775744f22c5a2";
+    const app = createApp();
+    const requestParams = createRequestParams({
+      client_id: knownClientId,
+      redirect_uri: knownRedirectUri,
+      response_type: "code",
+      scope: "openid phone",
+      prompt: "login",
+      state,
+    });
+    const response = await request(app).get(
+      authoriseEndpoint + "?" + requestParams
+    );
+    expect(response.status).toBe(302);
+    expect(response.header.location).toBe(
+      `${knownRedirectUri}?error=invalid_scope&error_description=${encodeURIComponent("Invalid, unknown or malformed scope")}&state=${state}`
+    );
+  });
+
+  it("returns 302 and redirects with an error for unknown claim", async () => {
+    const state = "a7e4bfd39d3eaa57c27775744f22c5a2";
+    const app = createApp();
+    const requestParams = createRequestParams({
+      client_id: knownClientId,
+      redirect_uri: knownRedirectUri,
+      response_type: "code",
+      scope: "openid email",
+      prompt: "login",
+      state,
+      claims: '{"userinfo":{"unknownClaim":null}}',
+    });
+    const response = await request(app).get(
+      authoriseEndpoint + "?" + requestParams
+    );
+    expect(response.status).toBe(302);
+    expect(response.header.location).toBe(
+      `${knownRedirectUri}?error=invalid_request&error_description=${encodeURIComponent("Request contains invalid claims")}&state=${state}`
+    );
+  });
+
+  it("returns 302 and redirects with an error for an unsupported claim", async () => {
+    const state = "a7e4bfd39d3eaa57c27775744f22c5a2";
+    const app = createApp();
+    const requestParams = createRequestParams({
+      client_id: knownClientId,
+      redirect_uri: knownRedirectUri,
+      response_type: "code",
+      scope: "openid email",
+      prompt: "login",
+      state,
+      claims: '{"userinfo":{"https://vocab.account.gov.uk/v1/passport":null}}',
+    });
+    const response = await request(app).get(
+      authoriseEndpoint + "?" + requestParams
+    );
+    expect(response.status).toBe(302);
+    expect(response.header.location).toBe(
+      `${knownRedirectUri}?error=invalid_request&error_description=${encodeURIComponent("Request contains invalid claims")}&state=${state}`
+    );
+  });
+
+  it("returns 302 and redirects with an error for no nonce value", async () => {
+    const state = "a7e4bfd39d3eaa57c27775744f22c5a2";
+    const app = createApp();
+    const requestParams = createRequestParams({
+      client_id: knownClientId,
+      redirect_uri: knownRedirectUri,
+      response_type: "code",
+      scope: "openid email",
+      prompt: "login",
+      state,
+      claims:
+        '{"userinfo":{"https://vocab.account.gov.uk/v1/coreIdentityJWT":null}}',
+    });
+    const response = await request(app).get(
+      authoriseEndpoint + "?" + requestParams
+    );
+    expect(response.status).toBe(302);
+    expect(response.header.location).toBe(
+      `${knownRedirectUri}?error=invalid_request&error_description=${encodeURIComponent("Request is missing nonce parameter")}&state=${state}`
+    );
+  });
+
+  it.each(["[]]", '["Ch"]', '["Cl.P2"]', '["Cl.Cm.P2","Cl.Cm"]'])(
+    "returns 302 and redirects with an error for invalid Vtr value %s",
+    async (vtrValue) => {
+      const state = "a7e4bfd39d3eaa57c27775744f22c5a2";
+      const app = createApp();
+      const requestParams = createRequestParams({
+        client_id: knownClientId,
+        redirect_uri: knownRedirectUri,
+        response_type: "code",
+        scope: "openid email",
+        prompt: "login",
+        state,
+        claims:
+          '{"userinfo":{"https://vocab.account.gov.uk/v1/coreIdentityJWT":null}}',
+        nonce: "3eb5b04ca8e1baf7dea15b7fb7ac05a6",
+        vtr: vtrValue,
+      });
+      const response = await request(app).get(
+        authoriseEndpoint + "?" + requestParams
+      );
+      expect(response.status).toBe(302);
+      expect(response.header.location).toBe(
+        `${knownRedirectUri}?error=invalid_request&error_description=${encodeURIComponent("Request vtr not valid")}&state=${state}`
+      );
+    }
+  );
+});
+
+describe("valid auth request", () => {
+  beforeEach(() => {
+    process.env.CLIENT_ID = knownClientId;
+    process.env.REDIRECT_URLS = knownRedirectUri;
+    process.env.SCOPES = "openid,email";
+    process.env.CLAIMS = "https://vocab.account.gov.uk/v1/coreIdentityJWT";
+    process.env.CLIENT_LOCS = "P2";
+    Config.resetInstance();
+  });
+
+  it("returns 302 and redirect with an auth code for a valid minimal auth request", async () => {
+    const state = "a7e4bfd39d3eaa57c27775744f22c5a2";
+    const nonce = "3eb5b04ca8e1baf7dea15b7fb7ac05a6";
+    const app = createApp();
+    const requestParams = createRequestParams({
+      client_id: knownClientId,
+      redirect_uri: knownRedirectUri,
+      response_type: "code",
+      scope: "openid email",
+      state,
+      nonce,
+    });
+    const response = await request(app).get(
+      authoriseEndpoint + "?" + requestParams
+    );
+    expect(response.status).toBe(302);
+    expect(response.header.location).toBe(
+      `${knownRedirectUri}?code=c87fe9af6880180fbb73a77597395053&state=${state}`
+    );
+  });
+
+  it("returns 302 and redirect with an auth code for a valid auth request with claims", async () => {
+    const state = "a7e4bfd39d3eaa57c27775744f22c5a2";
+    const nonce = "3eb5b04ca8e1baf7dea15b7fb7ac05a6";
+    const app = createApp();
+    const requestParams = createRequestParams({
+      client_id: knownClientId,
+      redirect_uri: knownRedirectUri,
+      response_type: "code",
+      scope: "openid email",
+      state,
+      claims:
+        '{"userinfo":{"https://vocab.account.gov.uk/v1/coreIdentityJWT":null}}',
+      nonce,
+    });
+    const response = await request(app).get(
+      authoriseEndpoint + "?" + requestParams
+    );
+    expect(response.status).toBe(302);
+    expect(response.header.location).toBe(
+      `${knownRedirectUri}?code=c87fe9af6880180fbb73a77597395053&state=${state}`
+    );
+  });
+
+  it("returns 302 and redirect with an auth code for a valid auth request with claims and prompt", async () => {
+    const state = "a7e4bfd39d3eaa57c27775744f22c5a2";
+    const nonce = "3eb5b04ca8e1baf7dea15b7fb7ac05a6";
+    const app = createApp();
+    const requestParams = createRequestParams({
+      client_id: knownClientId,
+      redirect_uri: knownRedirectUri,
+      response_type: "code",
+      scope: "openid email",
+      state,
+      claims:
+        '{"userinfo":{"https://vocab.account.gov.uk/v1/coreIdentityJWT":null}}',
+      nonce,
+      prompt: "login",
+    });
+    const response = await request(app).get(
+      authoriseEndpoint + "?" + requestParams
+    );
+    expect(response.status).toBe(302);
+    expect(response.header.location).toBe(
+      `${knownRedirectUri}?code=c87fe9af6880180fbb73a77597395053&state=${state}`
+    );
+  });
+
+  it("returns 302 and redirect with an auth code for a valid auth request with claims, prompt and valid vtr", async () => {
+    const state = "a7e4bfd39d3eaa57c27775744f22c5a2";
+    const nonce = "3eb5b04ca8e1baf7dea15b7fb7ac05a6";
+    const app = createApp();
+    const requestParams = createRequestParams({
+      client_id: knownClientId,
+      redirect_uri: knownRedirectUri,
+      response_type: "code",
+      scope: "openid email",
+      state,
+      claims:
+        '{"userinfo":{"https://vocab.account.gov.uk/v1/coreIdentityJWT":null}}',
+      nonce,
+      prompt: "login",
+      vtr: '["Cl.Cm.P2"]',
+    });
+    const response = await request(app).get(
+      authoriseEndpoint + "?" + requestParams
+    );
+    expect(response.status).toBe(302);
+    expect(response.header.location).toBe(
+      `${knownRedirectUri}?code=c87fe9af6880180fbb73a77597395053&state=${state}`
+    );
+  });
+});

--- a/src/components/config/tests/config-controller.test.ts
+++ b/src/components/config/tests/config-controller.test.ts
@@ -91,7 +91,7 @@ describe("Integration: Config POST", () => {
 
     expect(config.getClientId()).toEqual("HGIOgho9HIRhgoepdIOPFdIUWgewi0jw");
     expect(config.getPublicKey()).toEqual(TEST_PUBLIC_KEY);
-    expect(config.getScopes()).toEqual(["openid", "email", "password"]);
+    expect(config.getScopes()).toEqual(["openid", "email", "phone"]);
     expect(config.getRedirectUrls()).toEqual(TEST_REDIRECT_URLS);
     expect(config.getClaims()).toEqual(TEST_CLAIMS);
     expect(config.getIdentityVerificationSupported()).toEqual(true);

--- a/src/components/token/tests/helper/create-id-token.test.ts
+++ b/src/components/token/tests/helper/create-id-token.test.ts
@@ -18,6 +18,7 @@ describe("createIdToken tests", () => {
     redirectUri: "https://example.com/authentication-callback/",
     vtr: {
       credentialTrust: "Cl.Cm",
+      levelOfConfidence: null,
     },
   };
   const testTimestamp = 1723707024;

--- a/src/components/token/token-controller.ts
+++ b/src/components/token/token-controller.ts
@@ -4,7 +4,7 @@ import { Config } from "../../config";
 import { createAccessToken } from "./helper/create-access-token";
 import { createIdToken } from "./helper/create-id-token";
 import { TokenRequestError } from "../../errors/token-request-error";
-import { ParseRequestError } from "../../errors/parse-request-error";
+import { ParseTokenRequestError } from "../../errors/parse-token-request-error";
 import { parseTokenRequest } from "../../parse/parse-token-request";
 
 export const tokenController = async (
@@ -66,7 +66,7 @@ export const tokenController = async (
     if (error instanceof TokenRequestError) {
       handleTokenRequestError(error, res);
       return;
-    } else if (error instanceof ParseRequestError) {
+    } else if (error instanceof ParseTokenRequestError) {
       res.status(400).json({
         error: "invalid_request",
         error_description: "Invalid private_key_jwt",

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,7 +25,7 @@ CQIDAQAB
       publicKey: process.env.PUBLIC_KEY ?? defaultPublicKey,
       scopes: process.env.SCOPES
         ? process.env.SCOPES.split(",")
-        : ["openid", "email", "password"],
+        : ["openid", "email", "phone"],
       redirectUrls: process.env.REDIRECT_URLS
         ? process.env.REDIRECT_URLS.split(",")
         : ["http://localhost:8080/authorization-code/callback"],

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,33 @@
+export const VALID_SCOPES = ["openid", "email", "phone"];
+
+export const VALID_CLAIMS = [
+  "https://vocab.account.gov.uk/v1/passport",
+  "https://vocab.account.gov.uk/v1/address",
+  "https://vocab.account.gov.uk/v1/drivingPermit",
+  "https://vocab.account.gov.uk/v1/socialSecurityRecord",
+  "https://vocab.account.gov.uk/v1/coreIdentityJWT",
+  "https://vocab.account.gov.uk/v1/returnCode",
+  "https://vocab.account.gov.uk/v1/inheritedIdentityJWT",
+];
+
+export const VALID_CREDENTIAL_TRUST_VALUES = ["Cl", "Cl.Cm"];
+
+export const VALID_LOC_VALUES = ["P0", "P1", "P2"];
+
+//Whilst we don't support all of these we do need to reject
+//requests with invalid prompt values.
+export const VALID_OIDC_PROMPTS = [
+  "none",
+  "login",
+  "consent",
+  "select_account",
+];
+
+//We only support the code response_type, but
+// we need to reject invalid ones
+export const VALID_OIDC_RESPONSE_TYPES = ["token", "code", "id_token"];
+
+export const SUPPORTED_UI_LOCALES = ["en", "cy", "cy-AR"];
 export const ISSUER_VALUE = "https://oidc.account.gov.uk";
 export const EXPECTED_PRIVATE_KEY_JWT_AUDIENCE =
   "https://oidc.account.gov.uk/token";

--- a/src/errors/authorise-request-error.ts
+++ b/src/errors/authorise-request-error.ts
@@ -1,0 +1,22 @@
+export class AuthoriseRequestError extends Error {
+  public errorDescription: string;
+  public errorCode: string;
+  public httpStatusCode: number;
+  public redirectUri?: string;
+  public state?: string | null;
+
+  constructor(errorObject: {
+    errorCode: string;
+    errorDescription: string;
+    httpStatusCode: 302;
+    redirectUri: string;
+    state: string | null;
+  }) {
+    super(`${errorObject.errorCode}: ${errorObject.errorDescription}`);
+    this.errorCode = errorObject.errorCode;
+    this.errorDescription = errorObject.errorDescription;
+    this.httpStatusCode = errorObject.httpStatusCode;
+    this.state = errorObject.state;
+    this.redirectUri = errorObject.redirectUri;
+  }
+}

--- a/src/errors/bad-request-error.ts
+++ b/src/errors/bad-request-error.ts
@@ -1,0 +1,6 @@
+export class BadRequestError extends Error {
+  constructor(errorDescription: string) {
+    super();
+    this.message = `Invalid Request: ${errorDescription}`;
+  }
+}

--- a/src/errors/missing-parameter-error.ts
+++ b/src/errors/missing-parameter-error.ts
@@ -1,0 +1,6 @@
+export class MissingParameterError extends Error {
+  constructor(message: string) {
+    super();
+    this.message = message;
+  }
+}

--- a/src/errors/parse-auth-request-error.ts
+++ b/src/errors/parse-auth-request-error.ts
@@ -1,0 +1,11 @@
+export class ParseAuthRequestError extends Error {
+  public clientId?: string;
+  public redirectUri?: string;
+
+  constructor(message: string, clientId?: string, redirectUri?: string) {
+    super();
+    this.message = message;
+    this.clientId = clientId;
+    this.redirectUri = redirectUri;
+  }
+}

--- a/src/errors/parse-token-request-error.ts
+++ b/src/errors/parse-token-request-error.ts
@@ -1,4 +1,4 @@
-export class ParseRequestError extends Error {
+export class ParseTokenRequestError extends Error {
   constructor(message: string) {
     super();
     this.message = message;

--- a/src/middleware/dedupe-query-params.ts
+++ b/src/middleware/dedupe-query-params.ts
@@ -1,0 +1,51 @@
+import { NextFunction, Request, Response } from "express";
+import { logger } from "../logger";
+
+export const dedupeQueryParams = (
+  req: Request,
+  _res: Response,
+  next: NextFunction
+): void => {
+  const queryParams = req.query;
+
+  const dedupedParams = Object.entries(queryParams).reduce(
+    (dedupedParams: Record<string, string | undefined>, [key, value]) => {
+      if (typeof value === "string" || typeof value === "undefined") {
+        dedupedParams[key] = value;
+        return dedupedParams;
+      } else if (
+        Array.isArray(value) &&
+        value.every(
+          (param) => typeof param === "string" || typeof param === "undefined"
+        )
+      ) {
+        //Express will parse multiple instances of the same query param key as an array
+        //API gateway will ignore this and just use the last key-value pair in the path
+        //So we want to emulate the same behaviour here
+        dedupedParams[key] = value[value.length - 1];
+        logger.warn(
+          `Array of query params for key: "${key}" on path "${req.path}".` +
+            " \n This could indicate multiple instances of the same query param key or an array syntax being used." +
+            "\n These will be ignored and only the last instance of the key-value pair will be used"
+        );
+        return dedupedParams;
+      } else {
+        //Here the query param value is either an object or an array with some object values
+        //We explicitly want to drop these as API gateway does not support these kind of query parameters
+        //but the qs library express uses does
+        //https://expressjs.com/en/api.html#app.set:~:text=The%20extended%20query%20parser%20is%20based%20on%20qs.
+        //https://www.npmjs.com/package/qs#:~:text=qs%20allows%20you%20to%20create%20nested%20objects%20within%20your%20query%20strings%2C%20by%20surrounding%20the%20name%20of%20sub%2Dkeys%20with%20square%20brackets%20%5B%5D
+
+        logger.warn(
+          `Non primitive query param values for key: "${key}" on path ${req.path}, these will be dropped.` +
+            `\n Values: ${JSON.stringify(value, null, 4)} `
+        );
+        return dedupedParams;
+      }
+    },
+    {}
+  );
+
+  req.query = dedupedParams;
+  next();
+};

--- a/src/middleware/tests/dedupe-query-params.test.ts
+++ b/src/middleware/tests/dedupe-query-params.test.ts
@@ -1,0 +1,92 @@
+import { Response, Request } from "express";
+import { dedupeQueryParams } from "../dedupe-query-params";
+
+describe("dedupeQueryParams tests", () => {
+  it("returns string and undefined query params", () => {
+    const mockReq = {
+      query: {
+        key: "val",
+        key1: "val1",
+        key2: undefined,
+      },
+      path: "/endpoint",
+    } as unknown as Request;
+    const mockRes = {} as Response;
+    const mockNext = jest.fn();
+
+    dedupeQueryParams(mockReq, mockRes, mockNext);
+    expect(mockReq.query).toStrictEqual({
+      key: "val",
+      key1: "val1",
+      key2: undefined,
+    });
+    expect(mockNext).toHaveBeenCalled();
+  });
+
+  it("returns the last instance of an array of query params", () => {
+    const mockReq = {
+      query: {
+        key: "val",
+        key1: ["val1", "val2", "val3"],
+        key2: undefined,
+      },
+      path: "/endpoint",
+    } as unknown as Request;
+    const mockRes = {} as Response;
+    const mockNext = jest.fn();
+
+    dedupeQueryParams(mockReq, mockRes, mockNext);
+    expect(mockReq.query).toStrictEqual({
+      key: "val",
+      key1: "val3",
+      key2: undefined,
+    });
+    expect(mockNext).toHaveBeenCalled();
+  });
+
+  it("ignores any object query params", () => {
+    const mockReq = {
+      query: {
+        key: "val",
+        key1: ["val1", "val2", "val3"],
+        key2: {
+          someOtherKey: "val4",
+        },
+      },
+      path: "/endpoint",
+    } as unknown as Request;
+    const mockRes = {} as Response;
+    const mockNext = jest.fn();
+
+    dedupeQueryParams(mockReq, mockRes, mockNext);
+    expect(mockReq.query).toStrictEqual({
+      key: "val",
+      key1: "val3",
+    });
+    expect(mockNext).toHaveBeenCalled();
+  });
+
+  it("handles a mixture of cases", () => {
+    const mockReq = {
+      query: {
+        key: "val",
+        key1: ["val1", "val2", "val3"],
+        key2: undefined,
+        key3: {
+          someOtherKey: "val4",
+        },
+      },
+      path: "/endpoint",
+    } as unknown as Request;
+    const mockRes = {} as Response;
+    const mockNext = jest.fn();
+
+    dedupeQueryParams(mockReq, mockRes, mockNext);
+    expect(mockReq.query).toStrictEqual({
+      key: "val",
+      key1: "val3",
+      key2: undefined,
+    });
+    expect(mockNext).toHaveBeenCalled();
+  });
+});

--- a/src/parse/parse-auth-request-query-params.ts
+++ b/src/parse/parse-auth-request-query-params.ts
@@ -1,0 +1,300 @@
+import { vtrValidator } from "../validators/vtr-validator";
+import {
+  SUPPORTED_UI_LOCALES,
+  VALID_OIDC_PROMPTS,
+  VALID_OIDC_RESPONSE_TYPES,
+} from "../constants";
+import { ParseAuthRequestError } from "../errors/parse-auth-request-error";
+import { logger } from "../logger";
+import { Request } from "express";
+import { AuthoriseRequestError } from "../errors/authorise-request-error";
+import { BadRequestError } from "../errors/bad-request-error";
+import { Config } from "../config";
+import { areScopesValid } from "../validators/scope-validator";
+import { areClaimsValid } from "../validators/claims-validator";
+import { MissingParameterError } from "../errors/missing-parameter-error";
+import { VectorOfTrust } from "../types/vector-of-trust";
+
+export type ParsedAuthRequestQueryParams = {
+  response_type: string;
+  redirect_uri: string;
+  client_id: string;
+  state: string;
+  nonce: string;
+  scope: string[];
+  claims: string[];
+  vtr: VectorOfTrust[];
+  prompt: string[];
+  ui_locales: string[];
+};
+
+export const parseAuthQueryParams = (
+  queryParams: Record<string, string | undefined>,
+  config: Config
+): ParsedAuthRequestQueryParams => {
+  if (isEmptyRequest(queryParams)) {
+    throw new MissingParameterError(
+      "Invalid Request: No Query parameters present in request"
+    );
+  }
+
+  if (!queryParams.client_id) {
+    throw new MissingParameterError(
+      "Invalid Request: Missing client_id parameter"
+    );
+  }
+
+  if (!queryParams.response_type) {
+    throw new MissingParameterError(
+      "Invalid Request: Missing response_type parameter"
+    );
+  }
+
+  const includedPrompts = parsePrompts(
+    queryParams.prompt,
+    queryParams.client_id,
+    queryParams.redirect_uri
+  );
+
+  if (!queryParams.redirect_uri || !isValidUri(queryParams.redirect_uri)) {
+    throw new MissingParameterError(
+      "Invalid Request: Invalid redirect_uri parameter"
+    );
+  }
+
+  if (!queryParams.scope) {
+    throw new ParseAuthRequestError(
+      "Invalid Request: Missing scope parameter",
+      queryParams.client_id,
+      queryParams.redirect_uri
+    );
+  }
+
+  if (!isResponseTypeValid(queryParams.response_type)) {
+    throw new ParseAuthRequestError(
+      "Invalid Request: Unsupported response_type parameter",
+      queryParams.client_id,
+      queryParams.redirect_uri
+    );
+  }
+
+  //Scopes are space-delim https://datatracker.ietf.org/doc/html/rfc6749#section-3.3:~:text=The%20value%20of%20the%20scope%20parameter%20is%20expressed%20as%20a%20list%20of%20space%2D%0A%20%20%20delimited%2C%20case%2Dsensitive%20strings
+  const scopes = queryParams.scope.split(" ");
+
+  if (!scopes.includes("openid")) {
+    throw new ParseAuthRequestError(
+      "Invalid Request: The scope must include an openid value",
+      queryParams.client_id,
+      queryParams.redirect_uri
+    );
+  }
+
+  const uiLocales = parseUiLocales(queryParams.ui_locales);
+
+  const parsedClaims = parseClaims(
+    queryParams.claims,
+    queryParams.client_id,
+    queryParams.redirect_uri
+  );
+
+  if (config.getClientId() !== queryParams.client_id) {
+    throw new BadRequestError("Invalid request");
+  }
+
+  if (!config.getRedirectUrls().includes(queryParams.redirect_uri)) {
+    logger.warn(
+      "Redirect URI not valid for client: " + queryParams.redirect_uri
+    );
+    throw new BadRequestError("Invalid request");
+  }
+
+  if (!queryParams.state) {
+    throw new AuthoriseRequestError({
+      errorCode: "invalid_request",
+      errorDescription: "Request is missing state parameter",
+      httpStatusCode: 302,
+      redirectUri: queryParams.redirect_uri,
+      state: null,
+    });
+  }
+
+  if (queryParams.request_uri) {
+    logger.warn("Request URI parameter not supported");
+    throw new AuthoriseRequestError({
+      errorCode: "request_uri_not_supported",
+      errorDescription: "Request URI parameter not supported",
+      httpStatusCode: 302,
+      redirectUri: queryParams.redirect_uri,
+      state: queryParams.state,
+    });
+  }
+
+  if (queryParams.response_type !== "code") {
+    logger.error(
+      "Unsupported responseType included in request. Expected responseType of code"
+    );
+    throw new AuthoriseRequestError({
+      errorCode: "unsupported_response_type",
+      errorDescription: "Unsupported response type",
+      httpStatusCode: 302,
+      redirectUri: queryParams.redirect_uri,
+      state: queryParams.state,
+    });
+  }
+
+  if (!areScopesValid(scopes, config)) {
+    throw new AuthoriseRequestError({
+      errorCode: "invalid_scope",
+      errorDescription: "Invalid, unknown or malformed scope",
+      httpStatusCode: 302,
+      redirectUri: queryParams.redirect_uri,
+      state: queryParams.state,
+    });
+  }
+
+  if (!areClaimsValid(parsedClaims, config)) {
+    throw new AuthoriseRequestError({
+      errorCode: "invalid_request",
+      errorDescription: "Request contains invalid claims",
+      httpStatusCode: 302,
+      redirectUri: queryParams.redirect_uri,
+      state: queryParams.state,
+    });
+  }
+
+  if (!queryParams.nonce) {
+    logger.error("No nonce parameter included in authorisation request");
+    throw new AuthoriseRequestError({
+      errorCode: "invalid_request",
+      errorDescription: "Request is missing nonce parameter",
+      httpStatusCode: 302,
+      redirectUri: queryParams.redirect_uri,
+      state: queryParams.state,
+    });
+  }
+
+  const parsedVtrSet = vtrValidator(
+    queryParams.vtr,
+    config,
+    queryParams.state,
+    queryParams.redirect_uri
+  );
+
+  if (includedPrompts.includes("select_account")) {
+    throw new AuthoriseRequestError({
+      errorCode: "unmet_authentication_requirements",
+      errorDescription: "Unmet authentication requirements",
+      httpStatusCode: 302,
+      state: queryParams.state,
+      redirectUri: queryParams.redirect_uri,
+    });
+  }
+
+  return {
+    response_type: queryParams.response_type,
+    redirect_uri: queryParams.redirect_uri,
+    state: queryParams.state,
+    nonce: queryParams.nonce,
+    client_id: queryParams.client_id,
+    scope: scopes,
+    claims: parsedClaims,
+    vtr: parsedVtrSet,
+    prompt: includedPrompts,
+    ui_locales: uiLocales,
+  };
+};
+
+const isEmptyRequest = (queryParams: Request["query"]): boolean => {
+  return JSON.stringify(queryParams) === "{}";
+};
+
+const isValidUri = (uri: string): boolean => {
+  try {
+    new URL(uri);
+    return true;
+  } catch (error) {
+    logger.error("Error parsing redirect_uri: " + (error as Error).message);
+    return false;
+  }
+};
+
+const parsePrompts = (
+  prompt: string | undefined,
+  clientId: string,
+  redirectUri: string | undefined
+): string[] => {
+  if (!prompt) {
+    logger.info("No prompt value included in authorisation request");
+    return [];
+  }
+  //Prompt is space delimited string https://openid.net/specs/openid-connect-core-1_0-17.html#AuthorizationExamples:~:text=OPTIONAL.%20Space%20delimited
+  const includedPrompts = prompt.split(" ");
+
+  const invalidPrompts = includedPrompts.filter(
+    (prompt) => !VALID_OIDC_PROMPTS.includes(prompt)
+  );
+
+  if (invalidPrompts.length !== 0) {
+    logger.warn(
+      `Invalid prompts included in authorisation request: "${invalidPrompts}"`
+    );
+
+    throw new ParseAuthRequestError(
+      "Invalid Request: Invalid prompt parameter",
+      clientId,
+      redirectUri
+    );
+  }
+
+  return includedPrompts;
+};
+
+const isResponseTypeValid = (responseType: string): boolean =>
+  responseType.split(" ").every((rt) => VALID_OIDC_RESPONSE_TYPES.includes(rt));
+
+const parseClaims = (
+  claims: string | undefined,
+  clientId: string,
+  redirectUri: string
+): string[] => {
+  if (!claims) {
+    logger.info("No claims in authorisation request");
+    return [];
+  }
+  try {
+    const parsedClaimSet = JSON.parse(claims);
+
+    if (!parsedClaimSet.userinfo) {
+      logger.info("No userinfo claims included in authorisation request");
+      return [];
+    }
+
+    return Object.keys(parsedClaimSet.userinfo);
+  } catch (error) {
+    logger.error("Error parsing claims: " + (error as Error).message);
+    throw new ParseAuthRequestError(
+      "Invalid JSON in claims",
+      clientId,
+      redirectUri
+    );
+  }
+};
+
+const parseUiLocales = (uiLocales: string | undefined): string[] => {
+  if (!uiLocales) {
+    logger.info("No ui locales included in authorisation request");
+    return [];
+  }
+
+  const includedUiLocales = uiLocales.split(" ");
+
+  const unsupportedLocales = includedUiLocales.filter(
+    (uiLocale) => !SUPPORTED_UI_LOCALES.includes(uiLocale)
+  );
+
+  if (unsupportedLocales.length !== 0) {
+    logger.error("Unsupported ui locales included in authorisation request");
+  }
+
+  return includedUiLocales;
+};

--- a/src/parse/parse-token-request.ts
+++ b/src/parse/parse-token-request.ts
@@ -1,4 +1,4 @@
-import { ParseRequestError } from "../errors/parse-request-error";
+import { ParseTokenRequestError } from "../errors/parse-token-request-error";
 import { TokenRequestError } from "../errors/token-request-error";
 import { logger } from "../logger";
 import { TokenRequest } from "../types/token-request";
@@ -186,7 +186,7 @@ const parseClientAssertion = (
   const jwtParts = clientAssertion.split(".");
 
   if (jwtParts.length !== 3) {
-    throw new ParseRequestError(
+    throw new ParseTokenRequestError(
       "Invalid client_assertion JWT: Unexpected number of Base64URL parts, must be three"
     );
   }
@@ -197,7 +197,7 @@ const parseClientAssertion = (
   } catch (error) {
     if (error instanceof errors.JWTInvalid) {
       logger.error("Invalid JSON in client_assertion: " + error.message);
-      throw new ParseRequestError(
+      throw new ParseTokenRequestError(
         "Payload of JWS object is not a valid JSON object"
       );
     } else throw error;
@@ -206,31 +206,31 @@ const parseClientAssertion = (
   const signature = jwtParts[2];
 
   if (!signature || signature.trim().length === 0) {
-    throw new ParseRequestError(
+    throw new ParseTokenRequestError(
       "Invalid client_assertion JWT: The signature must not be empty"
     );
   }
 
   if (!payload.sub) {
-    throw new ParseRequestError(
+    throw new ParseTokenRequestError(
       "Invalid client_assertion JWT: Missing subject in client JWT assertion"
     );
   }
 
   if (!payload.iss) {
-    throw new ParseRequestError(
+    throw new ParseTokenRequestError(
       "Invalid client_assertion JWT: Missing issuer in client JWT assertion"
     );
   }
 
   if (!payload.aud) {
-    throw new ParseRequestError(
+    throw new ParseTokenRequestError(
       "Invalid client_assertion JWT: Missing audience in client JWT assertion"
     );
   }
 
   if (!payload.exp || typeof payload.exp !== "number") {
-    throw new ParseRequestError(
+    throw new ParseTokenRequestError(
       "Invalid client_assertion JWT: Missing or invalid expiry in client JWT assertion"
     );
   }
@@ -243,7 +243,7 @@ const parseClientAssertion = (
     );
 
     if (typeof payload.nbf !== "number") {
-      throw new ParseRequestError(
+      throw new ParseTokenRequestError(
         "Invalid client_assertion JWT: Invalid nbf claim in client JWT assertion"
       );
     }
@@ -256,7 +256,7 @@ const parseClientAssertion = (
   }
 
   if (payload.iat && typeof payload.iat !== "number") {
-    throw new ParseRequestError(
+    throw new ParseTokenRequestError(
       "Invalid client_assertion JWT: Invalid iat claim in client JWT assertion"
     );
   }
@@ -268,13 +268,13 @@ const parseClientAssertion = (
   }
 
   if (!header.alg || !["RS256", "ES256"].includes(header.alg)) {
-    throw new ParseRequestError(
+    throw new ParseTokenRequestError(
       "Invalid client_assertion JWT: The client assertion JWT must be RSA or ECDSA-signed (RS256, RS384, RS512, PS256, PS384, PS512, ES256, ES384 or ES512)"
     );
   }
 
   if (tokenRequestClientId && tokenRequestClientId !== payload.sub) {
-    throw new ParseRequestError(
+    throw new ParseTokenRequestError(
       "Invalid client_assertion JWT: The client identifier doesn't match the client assertion subject"
     );
   }

--- a/src/parse/tests/parse-auth-request-query-params.test.ts
+++ b/src/parse/tests/parse-auth-request-query-params.test.ts
@@ -1,0 +1,601 @@
+const areClaimsValidMock = jest.fn();
+const areScopesValidMock = jest.fn();
+const vtrValidatorMock = jest.fn();
+
+import { parseAuthQueryParams } from "../../parse/parse-auth-request-query-params";
+import { ParseAuthRequestError } from "../../errors/parse-auth-request-error";
+import { Config } from "../../config";
+import { BadRequestError } from "../../errors/bad-request-error";
+import { randomUUID } from "crypto";
+import { AuthoriseRequestError } from "../../errors/authorise-request-error";
+import { MissingParameterError } from "../../errors/missing-parameter-error";
+
+jest.mock("../../validators/claims-validator", () => ({
+  areClaimsValid: areClaimsValidMock,
+}));
+
+jest.mock("../../validators/scope-validator", () => ({
+  areScopesValid: areScopesValidMock,
+}));
+
+jest.mock("../../validators/vtr-validator", () => ({
+  vtrValidator: vtrValidatorMock,
+}));
+
+const clientId = "284e6ac9818525b254053711c9251fa7";
+const redirectUri = "https://example.com/authenication-callback";
+const clientLoCs = ["P0", "P2"];
+const claims = ["https://vocab.account.gov.uk/v1/passport"];
+const state = "6066cf5d190e2f1d5eeabaf089c01529ec47f7e3833d574f";
+const mockVtr = [
+  {
+    levelOfConfidence: null,
+    credentialTrust: "Cl.Cm",
+  },
+];
+
+describe("parseAuthRequestQueryParams tests", () => {
+  const config = Config.getInstance();
+
+  jest.spyOn(config, "getClientId").mockReturnValue(clientId);
+  jest.spyOn(config, "getRedirectUrls").mockReturnValue([redirectUri]);
+  jest.spyOn(config, "getClientLoCs").mockReturnValue(clientLoCs);
+  jest.spyOn(config, "getClaims").mockReturnValue(claims);
+
+  it("throws a missingParameter error for an empty request", () => {
+    expect(() => parseAuthQueryParams({}, config)).toThrow(
+      new MissingParameterError(
+        "Invalid Request: No Query parameters present in request"
+      )
+    );
+  });
+
+  it("throws a parse request error for no client_id", () => {
+    expect(() =>
+      parseAuthQueryParams(
+        {
+          response_type: "code",
+          redirect_uri: redirectUri,
+          state: state,
+          nonce: "8b5376320b7d9307627a5ad9512da4f84555d96fe9517365",
+          scope: "openid email phone",
+          claims:
+            '{"userinfo":{"https:\\/\\/vocab.account.gov.uk\\/v1\\/passport":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/coreIdentityJWT":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/address":{"essential":true}}}',
+          vtr: '["Cl.Cm"]',
+          prompt: "none",
+        },
+        config
+      )
+    ).toThrow(
+      new MissingParameterError("Invalid Request: Missing client_id parameter")
+    );
+  });
+
+  it("throws a parse request error for no response_type", () => {
+    expect(() =>
+      parseAuthQueryParams(
+        {
+          redirect_uri: redirectUri,
+          client_id: clientId,
+          state: state,
+          nonce: "8b5376320b7d9307627a5ad9512da4f84555d96fe9517365",
+          scope: "openid email phone",
+          claims:
+            '{"userinfo":{"https:\\/\\/vocab.account.gov.uk\\/v1\\/passport":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/coreIdentityJWT":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/address":{"essential":true}}}',
+          vtr: '["Cl.Cm"]',
+          prompt: "none",
+        },
+        config
+      )
+    ).toThrow(
+      new MissingParameterError(
+        "Invalid Request: Missing response_type parameter"
+      )
+    );
+  });
+
+  it("throws a parse request error if the prompt value is invalid", () => {
+    expect(() =>
+      parseAuthQueryParams(
+        {
+          response_type: "code",
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          state: state,
+          nonce: "8b5376320b7d9307627a5ad9512da4f84555d96fe9517365",
+          scope: "openid email phone",
+          claims:
+            '{"userinfo":{"https:\\/\\/vocab.account.gov.uk\\/v1\\/passport":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/coreIdentityJWT":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/address":{"essential":true}}}',
+          vtr: '["Cl.Cm"]',
+          prompt: "no-an-oidc-prompt",
+        },
+        config
+      )
+    ).toThrow(
+      new ParseAuthRequestError(
+        "Invalid Request: Invalid prompt parameter",
+        redirectUri,
+        clientId
+      )
+    );
+  });
+
+  it("throws a missing parameter error for no  redirect_uri", () => {
+    expect(() =>
+      parseAuthQueryParams(
+        {
+          response_type: "code",
+          client_id: clientId,
+          state: state,
+          nonce: "8b5376320b7d9307627a5ad9512da4f84555d96fe9517365",
+          scope: "openid email phone",
+          claims:
+            '{"userinfo":{"https:\\/\\/vocab.account.gov.uk\\/v1\\/passport":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/coreIdentityJWT":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/address":{"essential":true}}}',
+          vtr: '["Cl.Cm"]',
+          prompt: "none",
+        },
+        config
+      )
+    ).toThrow(
+      new MissingParameterError(
+        "Invalid Request: Invalid redirect_uri parameter"
+      )
+    );
+  });
+
+  it("throws a parse request error for an invalid redirect_uri", () => {
+    expect(() =>
+      parseAuthQueryParams(
+        {
+          response_type: "code",
+          client_id: clientId,
+          redirect_uri: "not-a-valid-uri",
+          state: state,
+          nonce: "8b5376320b7d9307627a5ad9512da4f84555d96fe9517365",
+          scope: "openid email phone",
+          claims:
+            '{"userinfo":{"https:\\/\\/vocab.account.gov.uk\\/v1\\/passport":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/coreIdentityJWT":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/address":{"essential":true}}}',
+          vtr: '["Cl.Cm"]',
+          prompt: "none",
+        },
+        config
+      )
+    ).toThrow(
+      new MissingParameterError(
+        "Invalid Request: Invalid redirect_uri parameter"
+      )
+    );
+  });
+
+  it("throws a parse request error for no scope", () => {
+    expect(() =>
+      parseAuthQueryParams(
+        {
+          client_id: clientId,
+          response_type: "code",
+          redirect_uri: redirectUri,
+          state: state,
+          nonce: "8b5376320b7d9307627a5ad9512da4f84555d96fe9517365",
+          claims:
+            '{"userinfo":{"https:\\/\\/vocab.account.gov.uk\\/v1\\/passport":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/coreIdentityJWT":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/address":{"essential":true}}}',
+          vtr: '["Cl.Cm"]',
+          prompt: "none",
+        },
+        config
+      )
+    ).toThrow(
+      new ParseAuthRequestError(
+        "Invalid Request: Missing scope parameter",
+        redirectUri,
+        clientId
+      )
+    );
+  });
+
+  it("throws a parse request error for a response_type that is not a valid OIDC respone_type", () => {
+    expect(() =>
+      parseAuthQueryParams(
+        {
+          client_id: clientId,
+          response_type: "notValid",
+          redirect_uri: redirectUri,
+          state: state,
+          nonce: "8b5376320b7d9307627a5ad9512da4f84555d96fe9517365",
+          claims:
+            '{"userinfo":{"https:\\/\\/vocab.account.gov.uk\\/v1\\/passport":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/coreIdentityJWT":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/address":{"essential":true}}}',
+          vtr: '["Cl.Cm"]',
+          prompt: "none",
+          scope: "openid",
+        },
+        config
+      )
+    ).toThrow(
+      new ParseAuthRequestError(
+        "Invalid Request: Unsupported response_type parameter",
+        redirectUri,
+        clientId
+      )
+    );
+  });
+
+  it("throws a parse request error for no openid scope", () => {
+    expect(() =>
+      parseAuthQueryParams(
+        {
+          client_id: clientId,
+          response_type: "code",
+          redirect_uri: redirectUri,
+          state: state,
+          nonce: "8b5376320b7d9307627a5ad9512da4f84555d96fe9517365",
+          claims:
+            '{"userinfo":{"https:\\/\\/vocab.account.gov.uk\\/v1\\/passport":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/coreIdentityJWT":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/address":{"essential":true}}}',
+          vtr: '["Cl.Cm"]',
+          scope: "email phone",
+          prompt: "none",
+        },
+        config
+      )
+    ).toThrow(
+      new ParseAuthRequestError(
+        "Invalid Request: The scope must include an openid value",
+        redirectUri,
+        clientId
+      )
+    );
+  });
+
+  it("throws a parse request error if the claims have invalid JSON", () => {
+    expect(() =>
+      parseAuthQueryParams(
+        {
+          response_type: "code",
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          state: state,
+          nonce: "8b5376320b7d9307627a5ad9512da4f84555d96fe9517365",
+          scope: "openid email phone",
+          claims: "{{{{{{{{{{}",
+          vtr: '["Cl.Cm"]',
+          prompt: "none",
+        },
+        config
+      )
+    ).toThrow(
+      new ParseAuthRequestError("Invalid JSON in claims", redirectUri, clientId)
+    );
+  });
+
+  it("throws a bad request error if the client id does not match the config ", () => {
+    areScopesValidMock.mockReturnValue(true);
+    vtrValidatorMock.mockReturnValue(mockVtr);
+    expect(() =>
+      parseAuthQueryParams(
+        {
+          response_type: "code",
+          client_id: "not-in-the-config",
+          redirect_uri: redirectUri,
+          state: state,
+          nonce: "8b5376320b7d9307627a5ad9512da4f84555d96fe9517365",
+          scope: "openid email phone",
+          claims:
+            '{"userinfo":{"https:\\/\\/vocab.account.gov.uk\\/v1\\/passport":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/coreIdentityJWT":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/address":{"essential":true}}}',
+          vtr: '["Cl.Cm"]',
+          prompt: "none",
+        },
+        config
+      )
+    ).toThrow(new BadRequestError("Invalid request"));
+  });
+
+  it("throws a bad request error if the redirect_uri is not in the config", () => {
+    areClaimsValidMock.mockReturnValue(true);
+    areScopesValidMock.mockReturnValue(true);
+    vtrValidatorMock.mockReturnValue(mockVtr);
+    expect(() =>
+      parseAuthQueryParams(
+        {
+          response_type: "code",
+          client_id: clientId,
+          redirect_uri: redirectUri + "/" + randomUUID(),
+          state: state,
+          nonce: "8b5376320b7d9307627a5ad9512da4f84555d96fe9517365",
+          scope: "openid email phone",
+          claims:
+            '{"userinfo":{"https:\\/\\/vocab.account.gov.uk\\/v1\\/passport":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/coreIdentityJWT":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/address":{"essential":true}}}',
+          vtr: '["Cl.Cm"]',
+          prompt: "none",
+        },
+        config
+      )
+    ).toThrow(new BadRequestError("Invalid request"));
+  });
+
+  it("throws an authoriseRequestError if there is no state value", () => {
+    areClaimsValidMock.mockReturnValue(true);
+    areScopesValidMock.mockReturnValue(true);
+    vtrValidatorMock.mockReturnValue(mockVtr);
+    expect(() =>
+      parseAuthQueryParams(
+        {
+          response_type: "code",
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          nonce: "8b5376320b7d9307627a5ad9512da4f84555d96fe9517365",
+          scope: "openid email phone",
+          claims:
+            '{"userinfo":{"https:\\/\\/vocab.account.gov.uk\\/v1\\/passport":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/coreIdentityJWT":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/address":{"essential":true}}}',
+          vtr: '["Cl.Cm"]',
+          prompt: "none",
+        },
+        config
+      )
+    ).toThrow(
+      new AuthoriseRequestError({
+        errorCode: "invalid_request",
+        errorDescription: "Request is missing state parameter",
+        httpStatusCode: 302,
+        redirectUri: redirectUri,
+        state: null,
+      })
+    );
+  });
+
+  it("throws an authoriseRequestError if the request_uri parameter is present ", () => {
+    areClaimsValidMock.mockReturnValue(true);
+    areScopesValidMock.mockReturnValue(true);
+    vtrValidatorMock.mockReturnValue(mockVtr);
+    expect(() =>
+      parseAuthQueryParams(
+        {
+          response_type: "code",
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          nonce: "8b5376320b7d9307627a5ad9512da4f84555d96fe9517365",
+          state: state,
+          scope: "openid email phone",
+          claims:
+            '{"userinfo":{"https:\\/\\/vocab.account.gov.uk\\/v1\\/passport":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/coreIdentityJWT":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/address":{"essential":true}}}',
+          vtr: '["Cl.Cm"]',
+          prompt: "none",
+          request_uri: "https://example.com/some-request-uri",
+        },
+        config
+      )
+    ).toThrow(
+      new AuthoriseRequestError({
+        errorCode: "request_uri_not_supported",
+        errorDescription: "Request URI parameter not supported",
+        httpStatusCode: 302,
+        redirectUri: redirectUri,
+        state: state,
+      })
+    );
+  });
+
+  it("throws an authoriseRequestError if the response_type is not code", () => {
+    areClaimsValidMock.mockReturnValue(true);
+    areScopesValidMock.mockReturnValue(true);
+    vtrValidatorMock.mockReturnValue(mockVtr);
+    expect(() =>
+      parseAuthQueryParams(
+        {
+          response_type: "token",
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          nonce: "8b5376320b7d9307627a5ad9512da4f84555d96fe9517365",
+          state: state,
+          scope: "openid email phone",
+          claims:
+            '{"userinfo":{"https:\\/\\/vocab.account.gov.uk\\/v1\\/passport":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/coreIdentityJWT":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/address":{"essential":true}}}',
+          vtr: '["Cl.Cm"]',
+          prompt: "none",
+        },
+        config
+      )
+    ).toThrow(
+      new AuthoriseRequestError({
+        errorCode: "unsupported_response_type",
+        errorDescription: "Unsupported response type",
+        httpStatusCode: 302,
+        redirectUri,
+        state,
+      })
+    );
+  });
+
+  it("throws an authoriseRequestError if the scopes are not valid", () => {
+    areScopesValidMock.mockReturnValue(false);
+    areClaimsValidMock.mockReturnValue(true);
+    vtrValidatorMock.mockReturnValue(mockVtr);
+
+    expect(() =>
+      parseAuthQueryParams(
+        {
+          response_type: "code",
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          nonce: "8b5376320b7d9307627a5ad9512da4f84555d96fe9517365",
+          state: state,
+          scope: "openid email phone",
+          claims:
+            '{"userinfo":{"https:\\/\\/vocab.account.gov.uk\\/v1\\/passport":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/coreIdentityJWT":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/address":{"essential":true}}}',
+          vtr: '["Cl.Cm"]',
+          prompt: "none",
+        },
+        config
+      )
+    ).toThrow(
+      new AuthoriseRequestError({
+        errorCode: "invalid_scope",
+        errorDescription: "Invalid, unknown or malformed scope",
+        httpStatusCode: 302,
+        redirectUri,
+        state,
+      })
+    );
+  });
+
+  it("throws an authoriseRequestError if the the claims are invalid", () => {
+    areScopesValidMock.mockReturnValue(true);
+    areClaimsValidMock.mockReturnValue(false);
+    vtrValidatorMock.mockReturnValue(mockVtr);
+    expect(() =>
+      parseAuthQueryParams(
+        {
+          response_type: "code",
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          nonce: "8b5376320b7d9307627a5ad9512da4f84555d96fe9517365",
+          state: state,
+          scope: "openid email phone",
+          claims:
+            '{"userinfo":{"https:\\/\\/vocab.account.gov.uk\\/v1\\/passport":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/coreIdentityJWT":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/address":{"essential":true}}}',
+          vtr: '["Cl.Cm"]',
+          prompt: "none",
+        },
+        config
+      )
+    ).toThrow(
+      new AuthoriseRequestError({
+        errorCode: "invalid_request",
+        errorDescription: "Request contains invalid claims",
+        httpStatusCode: 302,
+        redirectUri,
+        state,
+      })
+    );
+  });
+
+  it("throws an authoriseRequestError if there is no nonce included", () => {
+    areClaimsValidMock.mockReturnValue(true);
+    areScopesValidMock.mockReturnValue(true);
+    vtrValidatorMock.mockReturnValue(mockVtr);
+    expect(() =>
+      parseAuthQueryParams(
+        {
+          response_type: "code",
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          state: state,
+          scope: "openid email phone",
+          claims:
+            '{"userinfo":{"https:\\/\\/vocab.account.gov.uk\\/v1\\/passport":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/coreIdentityJWT":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/address":{"essential":true}}}',
+          vtr: '["Cl.Cm"]',
+          prompt: "none",
+        },
+        config
+      )
+    ).toThrow(
+      new AuthoriseRequestError({
+        errorCode: "invalid_request",
+        errorDescription: "Request is missing nonce parameter",
+        httpStatusCode: 302,
+        redirectUri: redirectUri,
+        state: state,
+      })
+    );
+  });
+
+  it("throws an error if the vtrValidator throws", () => {
+    areClaimsValidMock.mockReturnValue(true);
+    areScopesValidMock.mockReturnValue(true);
+    const error = new AuthoriseRequestError({
+      errorCode: "invalid_request",
+      errorDescription: "Request vtr not valid",
+      httpStatusCode: 302,
+      state,
+      redirectUri,
+    });
+    vtrValidatorMock.mockImplementation(() => {
+      throw error;
+    });
+
+    expect(() =>
+      parseAuthQueryParams(
+        {
+          response_type: "code",
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          state: state,
+          scope: "openid email phone",
+          claims:
+            '{"userinfo":{"https:\\/\\/vocab.account.gov.uk\\/v1\\/passport":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/coreIdentityJWT":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/address":{"essential":true}}}',
+          vtr: '["Cl.Cm"]',
+          nonce: "8b5376320b7d9307627a5ad9512da4f84555d96fe9517365",
+          prompt: "none",
+        },
+        config
+      )
+    ).toThrow(error);
+  });
+
+  it("throws an authoriseRequestError if the prompt includes select_account", () => {
+    areClaimsValidMock.mockReturnValue(true);
+    areScopesValidMock.mockReturnValue(true);
+    vtrValidatorMock.mockReturnValue(mockVtr);
+    expect(() =>
+      parseAuthQueryParams(
+        {
+          response_type: "code",
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          state: state,
+          scope: "openid email phone",
+          claims:
+            '{"userinfo":{"https:\\/\\/vocab.account.gov.uk\\/v1\\/passport":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/coreIdentityJWT":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/address":{"essential":true}}}',
+          vtr: '["Cl.Cm"]',
+          prompt: "select_account",
+          nonce: "8b5376320b7d9307627a5ad9512da4f84555d96fe9517365",
+        },
+        config
+      )
+    ).toThrow(
+      new AuthoriseRequestError({
+        errorCode: "unmet_authentication_requirements",
+        errorDescription: "Unmet authentication requirements",
+        httpStatusCode: 302,
+        state: state,
+        redirectUri: redirectUri,
+      })
+    );
+  });
+
+  it("returns a parsedAuthRequest ", () => {
+    areClaimsValidMock.mockReturnValue(true);
+    areScopesValidMock.mockReturnValue(true);
+    vtrValidatorMock.mockReturnValue(mockVtr);
+
+    expect(
+      parseAuthQueryParams(
+        {
+          response_type: "code",
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          state: state,
+          scope: "openid email phone",
+          claims:
+            '{"userinfo":{"https:\\/\\/vocab.account.gov.uk\\/v1\\/passport":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/coreIdentityJWT":{"essential":true},"https:\\/\\/vocab.account.gov.uk\\/v1\\/address":{"essential":true}}}',
+          vtr: '["Cl.Cm"]',
+          nonce: "8b5376320b7d9307627a5ad9512da4f84555d96fe9517365",
+          prompt: "none",
+        },
+        config
+      )
+    ).toStrictEqual({
+      response_type: "code",
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      state,
+      scope: ["openid", "email", "phone"],
+      claims: [
+        "https://vocab.account.gov.uk/v1/passport",
+        "https://vocab.account.gov.uk/v1/coreIdentityJWT",
+        "https://vocab.account.gov.uk/v1/address",
+      ],
+      vtr: mockVtr,
+      nonce: "8b5376320b7d9307627a5ad9512da4f84555d96fe9517365",
+      prompt: ["none"],
+      ui_locales: [],
+    });
+  });
+});

--- a/src/parse/tests/parse-token-request.test.ts
+++ b/src/parse/tests/parse-token-request.test.ts
@@ -1,7 +1,7 @@
 import { exportSPKI, SignJWT } from "jose";
 import { Config } from "../../config";
 import { EXPECTED_PRIVATE_KEY_JWT_AUDIENCE } from "../../constants";
-import { ParseRequestError } from "../../errors/parse-request-error";
+import { ParseTokenRequestError } from "../../errors/parse-token-request-error";
 import { TokenRequestError } from "../../errors/token-request-error";
 import { parseTokenRequest } from "../parse-token-request";
 import { generateKeyPairSync, randomUUID } from "crypto";
@@ -192,7 +192,7 @@ describe("parseTokenRequest tests", () => {
     );
   });
 
-  it("throws an ParseRequestError for an invalid JWS in the client_assertion", async () => {
+  it("throws an ParseTokenRequestError for an invalid JWS in the client_assertion", async () => {
     await expect(() =>
       parseTokenRequest(
         {
@@ -206,14 +206,14 @@ describe("parseTokenRequest tests", () => {
         config
       )
     ).rejects.toThrow(
-      new ParseRequestError(
+      new ParseTokenRequestError(
         "Invalid client_assertion JWT: " +
           "Unexpected number of Base64URL parts, must be three"
       )
     );
   });
 
-  it("throws an ParseRequestError if the payload is invalid JSON", async () => {
+  it("throws an ParseTokenRequestError if the payload is invalid JSON", async () => {
     await expect(() =>
       parseTokenRequest(
         {
@@ -232,11 +232,13 @@ describe("parseTokenRequest tests", () => {
         config
       )
     ).rejects.toThrow(
-      new ParseRequestError("Payload of JWS object is not a valid JSON object")
+      new ParseTokenRequestError(
+        "Payload of JWS object is not a valid JSON object"
+      )
     );
   });
 
-  it("throws an ParseRequestError if the signature is empty", async () => {
+  it("throws an ParseTokenRequestError if the signature is empty", async () => {
     await expect(() =>
       parseTokenRequest(
         {
@@ -262,13 +264,13 @@ describe("parseTokenRequest tests", () => {
         config
       )
     ).rejects.toThrow(
-      new ParseRequestError(
+      new ParseTokenRequestError(
         "Invalid client_assertion JWT: " + "The signature must not be empty"
       )
     );
   });
 
-  it("throws an ParseRequestError if there is no sub claim in the client_assertion", async () => {
+  it("throws an ParseTokenRequestError if there is no sub claim in the client_assertion", async () => {
     await expect(() =>
       parseTokenRequest(
         {
@@ -292,14 +294,14 @@ describe("parseTokenRequest tests", () => {
         config
       )
     ).rejects.toThrow(
-      new ParseRequestError(
+      new ParseTokenRequestError(
         "Invalid client_assertion JWT: " +
           "Missing subject in client JWT assertion"
       )
     );
   });
 
-  it("throws an ParseRequestError if there is no issuer in the client_assertion", async () => {
+  it("throws an ParseTokenRequestError if there is no issuer in the client_assertion", async () => {
     await expect(() =>
       parseTokenRequest(
         {
@@ -323,14 +325,14 @@ describe("parseTokenRequest tests", () => {
         config
       )
     ).rejects.toThrow(
-      new ParseRequestError(
+      new ParseTokenRequestError(
         "Invalid client_assertion JWT: " +
           "Missing issuer in client JWT assertion"
       )
     );
   });
 
-  it("throws an ParseRequestError if there is no aud in the client_assertion", async () => {
+  it("throws an ParseTokenRequestError if there is no aud in the client_assertion", async () => {
     await expect(() =>
       parseTokenRequest(
         {
@@ -354,14 +356,14 @@ describe("parseTokenRequest tests", () => {
         config
       )
     ).rejects.toThrow(
-      new ParseRequestError(
+      new ParseTokenRequestError(
         "Invalid client_assertion JWT: " +
           "Missing audience in client JWT assertion"
       )
     );
   });
 
-  it("throws an ParseRequestError if there is no exp in the client_assertion", async () => {
+  it("throws an ParseTokenRequestError if there is no exp in the client_assertion", async () => {
     await expect(() =>
       parseTokenRequest(
         {
@@ -385,14 +387,14 @@ describe("parseTokenRequest tests", () => {
         config
       )
     ).rejects.toThrow(
-      new ParseRequestError(
+      new ParseTokenRequestError(
         "Invalid client_assertion JWT: " +
           "Missing or invalid expiry in client JWT assertion"
       )
     );
   });
 
-  it("throws an ParseRequestError if the exp is invalid the client_assertion", async () => {
+  it("throws an ParseTokenRequestError if the exp is invalid the client_assertion", async () => {
     await expect(() =>
       parseTokenRequest(
         {
@@ -417,14 +419,14 @@ describe("parseTokenRequest tests", () => {
         config
       )
     ).rejects.toThrow(
-      new ParseRequestError(
+      new ParseTokenRequestError(
         "Invalid client_assertion JWT: " +
           "Missing or invalid expiry in client JWT assertion"
       )
     );
   });
 
-  it("throws an ParseRequestError if the nbf claim is invalid the client_assertion", async () => {
+  it("throws an ParseTokenRequestError if the nbf claim is invalid the client_assertion", async () => {
     await expect(() =>
       parseTokenRequest(
         {
@@ -450,14 +452,14 @@ describe("parseTokenRequest tests", () => {
         config
       )
     ).rejects.toThrow(
-      new ParseRequestError(
+      new ParseTokenRequestError(
         "Invalid client_assertion JWT: " +
           "Invalid nbf claim in client JWT assertion"
       )
     );
   });
 
-  it("throws an ParseRequestError if the nbf claim is invalid the client_assertion", async () => {
+  it("throws an ParseTokenRequestError if the nbf claim is invalid the client_assertion", async () => {
     await expect(() =>
       parseTokenRequest(
         {
@@ -483,14 +485,14 @@ describe("parseTokenRequest tests", () => {
         config
       )
     ).rejects.toThrow(
-      new ParseRequestError(
+      new ParseTokenRequestError(
         "Invalid client_assertion JWT: " +
           "Invalid iat claim in client JWT assertion"
       )
     );
   });
 
-  it("throws an ParseRequestError if there is no alg in the header", async () => {
+  it("throws an ParseTokenRequestError if there is no alg in the header", async () => {
     await expect(() =>
       parseTokenRequest(
         {
@@ -513,14 +515,14 @@ describe("parseTokenRequest tests", () => {
         config
       )
     ).rejects.toThrow(
-      new ParseRequestError(
+      new ParseTokenRequestError(
         "Invalid client_assertion JWT: " +
           "The client assertion JWT must be RSA or ECDSA-signed (RS256, RS384, RS512, PS256, PS384, PS512, ES256, ES384 or ES512)"
       )
     );
   });
 
-  it("throws an ParseRequestError if the alg in the header is not RS256 or ES256", async () => {
+  it("throws an ParseTokenRequestError if the alg in the header is not RS256 or ES256", async () => {
     await expect(() =>
       parseTokenRequest(
         {
@@ -545,7 +547,7 @@ describe("parseTokenRequest tests", () => {
         config
       )
     ).rejects.toThrow(
-      new ParseRequestError(
+      new ParseTokenRequestError(
         "Invalid client_assertion JWT: " +
           "The client assertion JWT must be RSA or ECDSA-signed (RS256, RS384, RS512, PS256, PS384, PS512, ES256, ES384 or ES512)"
       )
@@ -579,7 +581,7 @@ describe("parseTokenRequest tests", () => {
         config
       )
     ).rejects.toThrow(
-      new ParseRequestError(
+      new ParseTokenRequestError(
         "Invalid client_assertion JWT: " +
           "The client identifier doesn't match the client assertion subject"
       )

--- a/src/types/auth-request-parameters.ts
+++ b/src/types/auth-request-parameters.ts
@@ -1,10 +1,9 @@
+import { VectorOfTrust } from "./vector-of-trust";
+
 export default interface AuthRequestParameters {
   redirectUri: string;
   nonce: string;
   scopes: string[];
   claims: string[];
-  vtr: {
-    credentialTrust: "Cl" | "Cl.Cm";
-    levelOfConfidence?: "P0" | "P2";
-  };
+  vtr: VectorOfTrust;
 }

--- a/src/types/vector-of-trust.ts
+++ b/src/types/vector-of-trust.ts
@@ -1,0 +1,4 @@
+export type VectorOfTrust = {
+  credentialTrust: "Cl" | "Cl.Cm";
+  levelOfConfidence: null | "P0" | "P1" | "P2";
+};

--- a/src/validators/claims-validator.ts
+++ b/src/validators/claims-validator.ts
@@ -1,0 +1,29 @@
+import { logger } from "../logger";
+import { Config } from "../config";
+import { VALID_CLAIMS } from "../constants";
+
+export const areClaimsValid = (claims: string[], config: Config): boolean => {
+  const clientClaims = config.getClaims();
+
+  const invalidClaims = claims.filter((claim) => !VALID_CLAIMS.includes(claim));
+
+  if (invalidClaims.length !== 0) {
+    logger.error(
+      "Invalid claims included in request" + invalidClaims.join(", ")
+    );
+    return false;
+  }
+
+  const unsupportedClaims = claims.filter(
+    (claim) => !clientClaims.includes(claim)
+  );
+
+  if (unsupportedClaims.length !== 0) {
+    logger.error(
+      `Request contains claims unsupported by client: Unsupported Claims: ${unsupportedClaims.join(", ")} Client Claims: ${clientClaims}`
+    );
+    return false;
+  }
+
+  return true;
+};

--- a/src/validators/scope-validator.ts
+++ b/src/validators/scope-validator.ts
@@ -1,0 +1,28 @@
+import { logger } from "../logger";
+import { Config } from "../config";
+import { VALID_SCOPES } from "../constants";
+
+export const areScopesValid = (scopes: string[], config: Config): boolean => {
+  const invalidScopes = scopes.filter((scope) => !VALID_SCOPES.includes(scope));
+
+  if (invalidScopes.length > 0) {
+    logger.warn("Request included invalid scopes: " + invalidScopes.join(", "));
+    return false;
+  }
+
+  const clientScopes = config.getScopes();
+
+  const unsupportedScopes = scopes.filter(
+    (scope) => !clientScopes.includes(scope)
+  );
+
+  if (unsupportedScopes.length > 0) {
+    logger.warn(
+      "Request included scopes not supported by the client: " +
+        unsupportedScopes.join(", ")
+    );
+    return false;
+  }
+
+  return true;
+};

--- a/src/validators/tests/claims-validator.test.ts
+++ b/src/validators/tests/claims-validator.test.ts
@@ -1,0 +1,53 @@
+import { Config } from "../../config";
+import { areClaimsValid } from "../claims-validator";
+
+describe("claims validation tests", () => {
+  const config = Config.getInstance();
+
+  const claimsSpy = jest.spyOn(config, "getClaims");
+
+  it("returns true if the claims are empty", () => {
+    claimsSpy.mockReturnValue([
+      "https://vocab.account.gov.uk/v1/coreIdentityJWT",
+    ]);
+
+    expect(areClaimsValid([], config)).toBe(true);
+  });
+
+  it("returns false for unknown claims", () => {
+    claimsSpy.mockReturnValue([
+      "https://vocab.account.gov.uk/v1/coreIdentityJWT",
+    ]);
+
+    expect(
+      areClaimsValid(["https://vocab.account.gov.uk/v1/unknownClaim"], config)
+    ).toBe(false);
+  });
+
+  it("returns false if the claims are not supported by the client", () => {
+    claimsSpy.mockReturnValue([
+      "https://vocab.account.gov.uk/v1/coreIdentityJWT",
+    ]);
+
+    expect(
+      areClaimsValid(["https://vocab.account.gov.uk/v1/returnCode"], config)
+    ).toBe(false);
+  });
+
+  it("returns true if all the claims are known and supported by the client", () => {
+    claimsSpy.mockReturnValue([
+      "https://vocab.account.gov.uk/v1/coreIdentityJWT",
+      "https://vocab.account.gov.uk/v1/returnCode",
+    ]);
+
+    expect(
+      areClaimsValid(
+        [
+          "https://vocab.account.gov.uk/v1/coreIdentityJWT",
+          "https://vocab.account.gov.uk/v1/returnCode",
+        ],
+        config
+      )
+    ).toBe(true);
+  });
+});

--- a/src/validators/tests/scope-validator.test.ts
+++ b/src/validators/tests/scope-validator.test.ts
@@ -1,0 +1,25 @@
+import { Config } from "../../config";
+import { areScopesValid } from "../scope-validator";
+
+describe("scope validator tests", () => {
+  const config = Config.getInstance();
+  const scopesSpy = jest.spyOn(config, "getScopes");
+
+  it("returns false for any invalid scopes", () => {
+    scopesSpy.mockReturnValue(["openid", "phone"]);
+
+    expect(areScopesValid(["openid", "nickname"], config)).toBe(false);
+  });
+
+  it("returns false for any unsupported scopes", () => {
+    scopesSpy.mockReturnValue(["openid", "phone"]);
+
+    expect(areScopesValid(["openid", "email"], config)).toBe(false);
+  });
+
+  it("returns true if the scopes are valid and known", () => {
+    scopesSpy.mockReturnValue(["openid", "email"]);
+
+    expect(areScopesValid(["openid", "email"], config)).toBe(true);
+  });
+});

--- a/src/validators/tests/vtr-validator.test.ts
+++ b/src/validators/tests/vtr-validator.test.ts
@@ -1,0 +1,206 @@
+import { Config } from "../../config";
+import { AuthoriseRequestError } from "../../errors/authorise-request-error";
+import { vtrValidator } from "../vtr-validator";
+
+describe("vtrValidator tests", () => {
+  const config = Config.getInstance();
+
+  const levelOfConfidenceSpy = jest.spyOn(config, "getClientLoCs");
+  const state = "4063a64d651d9077adee7c51a26e87e8";
+  const redirectUri = "https://example.com/authentication-callback";
+
+  it("returns the default credential trust and level of confidence when vtr is undefined", () => {
+    levelOfConfidenceSpy.mockReturnValue(["P0", "P2"]);
+
+    expect(vtrValidator(undefined, config, state, redirectUri)).toStrictEqual([
+      {
+        levelOfConfidence: null,
+        credentialTrust: "Cl.Cm",
+      },
+    ]);
+  });
+
+  it("throws an error when a vtr includes more than 1 identity component", () => {
+    levelOfConfidenceSpy.mockReturnValue(["P0", "P2"]);
+
+    expect(() =>
+      vtrValidator('["Cl.Cm.P2.P0"]', config, state, redirectUri)
+    ).toThrow(
+      new AuthoriseRequestError({
+        errorCode: "invalid_request",
+        errorDescription: "Request vtr not valid",
+        httpStatusCode: 302,
+        state,
+        redirectUri,
+      })
+    );
+  });
+
+  it("ignores any unknown values", () => {
+    levelOfConfidenceSpy.mockReturnValue(["P0", "P2"]);
+
+    expect(
+      vtrValidator('["Cl.Cm.P2.D4"]', config, state, redirectUri)
+    ).toStrictEqual([
+      {
+        credentialTrust: "Cl.Cm",
+        levelOfConfidence: "P2",
+      },
+    ]);
+  });
+
+  it("throws an error when a vtr includes an unsupported credential trust value", () => {
+    levelOfConfidenceSpy.mockReturnValue(["P0", "P2"]);
+
+    expect(() => vtrValidator('["Ch.P2"]', config, state, redirectUri)).toThrow(
+      new AuthoriseRequestError({
+        errorCode: "invalid_request",
+        errorDescription: "Request vtr not valid",
+        httpStatusCode: 302,
+        state,
+        redirectUri,
+      })
+    );
+  });
+
+  it("throws an error when a vtr includes an invalid level of identity confidence", () => {
+    levelOfConfidenceSpy.mockReturnValue(["P0", "P2"]);
+
+    expect(() =>
+      vtrValidator('["Cl.Cm.P3"]', config, state, redirectUri)
+    ).toThrow(
+      new AuthoriseRequestError({
+        errorCode: "invalid_request",
+        errorDescription: "Request vtr not valid",
+        httpStatusCode: 302,
+        state,
+        redirectUri,
+      })
+    );
+  });
+
+  it("throws an error when a vtr specified P2 confidence with an credential trust value of Cl", () => {
+    levelOfConfidenceSpy.mockReturnValue(["P0", "P2"]);
+
+    expect(() => vtrValidator('["Cl.P2"]', config, state, redirectUri)).toThrow(
+      new AuthoriseRequestError({
+        errorCode: "invalid_request",
+        errorDescription: "Request vtr not valid",
+        httpStatusCode: 302,
+        state,
+        redirectUri,
+      })
+    );
+  });
+
+  it("throws an error when a vtr specified P1 confidence with an credential trust value of Cl", () => {
+    levelOfConfidenceSpy.mockReturnValue(["P0", "P1", "P2"]);
+
+    expect(() => vtrValidator('["Cl.P1"]', config, state, redirectUri)).toThrow(
+      new AuthoriseRequestError({
+        errorCode: "invalid_request",
+        errorDescription: "Request vtr not valid",
+        httpStatusCode: 302,
+        state,
+        redirectUri,
+      })
+    );
+  });
+
+  it("throws an error when a vtr set includes both identity and non identity components", () => {
+    levelOfConfidenceSpy.mockReturnValue(["P0", "P2"]);
+
+    expect(() =>
+      vtrValidator('["Cl.Cm.P2", "Cl.Cm"]', config, state, redirectUri)
+    ).toThrow(
+      new AuthoriseRequestError({
+        errorCode: "invalid_request",
+        errorDescription: "Request vtr not valid",
+        httpStatusCode: 302,
+        state,
+        redirectUri,
+      })
+    );
+  });
+
+  it("throws an error when a vtr set includes levels of identity confidence not supported by the client", () => {
+    levelOfConfidenceSpy.mockReturnValue(["P2"]);
+
+    expect(() =>
+      vtrValidator('["Cl.Cm.P2", "Cl.Cm.P0"]', config, state, redirectUri)
+    ).toThrow(
+      new AuthoriseRequestError({
+        errorCode: "invalid_request",
+        errorDescription: "Request vtr not valid",
+        httpStatusCode: 302,
+        state,
+        redirectUri,
+      })
+    );
+  });
+
+  it("throws an error when a vtr set is an invalid JSON array", () => {
+    levelOfConfidenceSpy.mockReturnValue(["P0", "P2"]);
+
+    expect(() =>
+      vtrValidator('["Cl.Cm.P2", "Cl.Cm.P0"]]]', config, state, redirectUri)
+    ).toThrow(
+      new AuthoriseRequestError({
+        errorCode: "invalid_request",
+        errorDescription: "Request vtr not valid",
+        httpStatusCode: 302,
+        state,
+        redirectUri,
+      })
+    );
+  });
+
+  it("does not allow both identity and non-identity components in the vtr with a P0", () => {
+    levelOfConfidenceSpy.mockReturnValue(["P0", "P2"]);
+
+    expect(() =>
+      vtrValidator('["Cl.Cm.P2", "Cl.Cm.P0"]]]', config, state, redirectUri)
+    ).toThrow(
+      new AuthoriseRequestError({
+        errorCode: "invalid_request",
+        errorDescription: "Request vtr not valid",
+        httpStatusCode: 302,
+        state,
+        redirectUri,
+      })
+    );
+  });
+
+  it("does not allow both identity and non-identity implicitly", () => {
+    levelOfConfidenceSpy.mockReturnValue(["P0", "P2"]);
+
+    expect(() =>
+      vtrValidator('["Cl.Cm.P2", "Cl.Cm"]]]', config, state, redirectUri)
+    ).toThrow(
+      new AuthoriseRequestError({
+        errorCode: "invalid_request",
+        errorDescription: "Request vtr not valid",
+        httpStatusCode: 302,
+        state,
+        redirectUri,
+      })
+    );
+  });
+
+  it("returns a parsed valid vtr set", () => {
+    levelOfConfidenceSpy.mockReturnValue(["P1", "P2"]);
+
+    expect(
+      vtrValidator('["Cl.Cm.P2", "Cl.Cm.P1"]', config, state, redirectUri)
+    ).toStrictEqual([
+      {
+        levelOfConfidence: "P2",
+        credentialTrust: "Cl.Cm",
+      },
+      {
+        levelOfConfidence: "P1",
+        credentialTrust: "Cl.Cm",
+      },
+    ]);
+  });
+});

--- a/src/validators/vtr-validator.ts
+++ b/src/validators/vtr-validator.ts
@@ -1,0 +1,134 @@
+import { Config } from "../config";
+import { AuthoriseRequestError } from "../errors/authorise-request-error";
+import { logger } from "../logger";
+import { VALID_CREDENTIAL_TRUST_VALUES, VALID_LOC_VALUES } from "../constants";
+import { VectorOfTrust } from "../types/vector-of-trust";
+
+export const vtrValidator = (
+  vtr: string | undefined,
+  config: Config,
+  state: string,
+  redirectUri: string
+): VectorOfTrust[] => {
+  if (!vtr) {
+    logger.info("No vtr value provided, attaching default credential trust");
+    return [
+      {
+        levelOfConfidence: null,
+        credentialTrust: "Cl.Cm",
+      },
+    ];
+  }
+
+  let vtrSet: string[];
+  let parsedVtrSet: VectorOfTrust[];
+
+  try {
+    vtrSet = JSON.parse(vtr);
+    parsedVtrSet = vtrSet.map(parseSingleVtr);
+  } catch (error) {
+    logger.error("Error parsing vtr value: " + (error as Error).message);
+    throw generateInvalidVtrError(redirectUri, state);
+  }
+
+  const clientLevelsOfConfidence = config.getClientLoCs();
+
+  const identityVectors = parsedVtrSet
+    .map((vector) => vector.levelOfConfidence)
+    .filter(
+      (levelOfConfidence) =>
+        levelOfConfidence !== null && levelOfConfidence !== "P0"
+    );
+
+  if (
+    identityVectors.length !== 0 &&
+    identityVectors.length < parsedVtrSet.length
+  ) {
+    logger.error("VTR cannot contain both identity and non-identity vectors");
+    throw generateInvalidVtrError(redirectUri, state);
+  }
+
+  if (!identityVectors.every((loc) => clientLevelsOfConfidence.includes(loc))) {
+    logger.error(
+      "Level of confidence values have been requested which this client is not permitted to request. Level of confidence values in request: " +
+        identityVectors.join(" ")
+    );
+    throw generateInvalidVtrError(redirectUri, state);
+  }
+
+  return parsedVtrSet;
+};
+
+const parseSingleVtr = (singleVtr: string): VectorOfTrust => {
+  const splitVtrValues = singleVtr.split(".");
+
+  const credentialTrustValue = splitVtrValues
+    .filter(isCredentialTrust)
+    .sort()
+    .join(".") as "Cl" | "Cl.Cm";
+
+  const providedLevelsOfConfidence = splitVtrValues.filter(isVectorOfTrust);
+  const unknownValues = splitVtrValues.filter(isUnknown);
+
+  if (
+    !providedLevelsOfConfidence.every((loc) => VALID_LOC_VALUES.includes(loc))
+  ) {
+    throw new Error("Invalid LevelOfConfidence provided");
+  }
+
+  if (providedLevelsOfConfidence.length > 1) {
+    throw new Error(
+      "VTR must contain either 0 or 1 identity proofing components"
+    );
+  }
+
+  if (unknownValues.length !== 0) {
+    logger.warn(
+      `Unknown values in VTR, these will be ignored: ${unknownValues}`
+    );
+  }
+
+  if (!VALID_CREDENTIAL_TRUST_VALUES.includes(credentialTrustValue)) {
+    throw new Error("Invalid Credential Trust Value provided");
+  }
+
+  const parsedVtr: VectorOfTrust = {
+    credentialTrust: credentialTrustValue,
+    levelOfConfidence: providedLevelsOfConfidence[0] ?? null,
+  };
+
+  if (
+    (parsedVtr.levelOfConfidence !== null ||
+      parsedVtr.levelOfConfidence !== "P0") &&
+    parsedVtr.credentialTrust !== "Cl.Cm"
+  ) {
+    throw new Error(
+      "Non zero identity confidence must require at least Cl.Cm credential trust"
+    );
+  }
+
+  return parsedVtr;
+};
+
+const isCredentialTrust = (
+  credentialTrust: string
+): credentialTrust is "Cl" | "Cm" => credentialTrust.startsWith("C");
+
+const isVectorOfTrust = (
+  levelOfConfidence: string
+): levelOfConfidence is "P0" | "P1" | "P2" => levelOfConfidence.startsWith("P");
+
+const isUnknown = (vtr: string): boolean =>
+  !isCredentialTrust(vtr) && !isVectorOfTrust(vtr);
+
+const generateInvalidVtrError = (
+  redirectUri: string,
+  state: string
+): AuthoriseRequestError =>
+  new AuthoriseRequestError({
+    errorCode: "invalid_request",
+    errorDescription: "Request vtr not valid",
+    httpStatusCode: 302,
+    state,
+    redirectUri,
+  });

--- a/tests/integration/app.test.ts
+++ b/tests/integration/app.test.ts
@@ -3,7 +3,7 @@ import request from "supertest";
 
 describe("Integration: Healthcheck", () => {
   test("Healthcheck endpoint returns 200", async () => {
-    const app = await createApp();
+    const app = createApp();
     const response = await request(app).get("/");
     expect(response.status).toEqual(200);
     expect(response.text).toEqual("Express + TypeScript Server");

--- a/tests/integration/token.test.ts
+++ b/tests/integration/token.test.ts
@@ -444,6 +444,7 @@ describe("/token endpoint valid client_assertion", () => {
     claims: [],
     vtr: {
       credentialTrust: "Cl.Cm",
+      levelOfConfidence: null,
     },
   };
   const redirectUriMismatchParams: AuthRequestParameters = {
@@ -453,6 +454,7 @@ describe("/token endpoint valid client_assertion", () => {
     claims: [],
     vtr: {
       credentialTrust: "Cl.Cm",
+      levelOfConfidence: null,
     },
   };
 

--- a/tests/integration/token.test.ts
+++ b/tests/integration/token.test.ts
@@ -68,7 +68,7 @@ const setupClientConfig = async (
 
 describe("/token endpoint tests, invalid request", () => {
   it("returns an invalid_request error for missing grant_type", async () => {
-    const app = await createApp();
+    const app = createApp();
     const response = await request(app).post(TOKEN_ENDPOINT).send({
       code: "123456",
       redirect_uri: "http://localhost:8080/authorization-code/callback",
@@ -86,7 +86,7 @@ describe("/token endpoint tests, invalid request", () => {
   });
 
   it("returns an invalid_request error when grant_type is not authorization_code", async () => {
-    const app = await createApp();
+    const app = createApp();
     const response = await request(app).post(TOKEN_ENDPOINT).send({
       grant_type: "not_authorization_code",
       code: "123456",
@@ -105,7 +105,7 @@ describe("/token endpoint tests, invalid request", () => {
   });
 
   it("returns an invalid_request no redirect_uri is included", async () => {
-    const app = await createApp();
+    const app = createApp();
     const response = await request(app).post(TOKEN_ENDPOINT).send({
       grant_type: "authorization_code",
       code: "123456",
@@ -123,7 +123,7 @@ describe("/token endpoint tests, invalid request", () => {
   });
 
   it("returns an invalid_request when no auth_code is included", async () => {
-    const app = await createApp();
+    const app = createApp();
     const response = await request(app).post(TOKEN_ENDPOINT).send({
       grant_type: "authorization_code",
       redirect_uri: "http://localhost:8080/authorization-code/callback",
@@ -141,7 +141,7 @@ describe("/token endpoint tests, invalid request", () => {
   });
 
   it("returns an invalid_request when the client_assertion_type is not included", async () => {
-    const app = await createApp();
+    const app = createApp();
     const response = await request(app).post(TOKEN_ENDPOINT).send({
       grant_type: "authorization_code",
       code: "123456",
@@ -158,7 +158,7 @@ describe("/token endpoint tests, invalid request", () => {
   });
 
   it("returns an invalid_request when the client_assertion is not included", async () => {
-    const app = await createApp();
+    const app = createApp();
     const response = await request(app).post(TOKEN_ENDPOINT).send({
       grant_type: "authorization_code",
       code: "123456",
@@ -175,7 +175,7 @@ describe("/token endpoint tests, invalid request", () => {
   });
 
   it("returns an invalid_request when the client_assertion is not included", async () => {
-    const app = await createApp();
+    const app = createApp();
     const response = await request(app).post(TOKEN_ENDPOINT).send({
       grant_type: "authorization_code",
       code: "123456",
@@ -192,7 +192,7 @@ describe("/token endpoint tests, invalid request", () => {
   });
 
   it("returns an invalid_request when the client_assertion_type is not included", async () => {
-    const app = await createApp();
+    const app = createApp();
     const response = await request(app).post(TOKEN_ENDPOINT).send({
       grant_type: "authorization_code",
       code: "123456",
@@ -225,7 +225,7 @@ describe("/token endpoint tests, invalid client assertion", () => {
       "." +
       fakeSignature();
 
-    const app = await createApp();
+    const app = createApp();
     const response = await request(app).post(TOKEN_ENDPOINT).send({
       grant_type: "authorization_code",
       code: "123456",
@@ -254,7 +254,7 @@ describe("/token endpoint tests, invalid client assertion", () => {
       "." +
       fakeSignature();
 
-    const app = await createApp();
+    const app = createApp();
     const response = await request(app).post(TOKEN_ENDPOINT).send({
       grant_type: "authorization_code",
       code: "123456",
@@ -284,7 +284,7 @@ describe("/token endpoint tests, invalid client assertion", () => {
       "." +
       fakeSignature();
 
-    const app = await createApp();
+    const app = createApp();
     const response = await request(app).post(TOKEN_ENDPOINT).send({
       grant_type: "authorization_code",
       code: "123456",
@@ -314,7 +314,7 @@ describe("/token endpoint tests, invalid client assertion", () => {
       "." +
       fakeSignature();
 
-    const app = await createApp();
+    const app = createApp();
     const response = await request(app).post(TOKEN_ENDPOINT).send({
       grant_type: "authorization_code",
       code: "123456",
@@ -347,7 +347,7 @@ describe("/token endpoint tests, invalid client assertion", () => {
       "." +
       fakeSignature();
 
-    const app = await createApp();
+    const app = createApp();
     const response = await request(app).post(TOKEN_ENDPOINT).send({
       grant_type: "authorization_code",
       code: "123456",
@@ -377,7 +377,7 @@ describe("/token endpoint tests, invalid client assertion", () => {
       "." +
       fakeSignature();
 
-    const app = await createApp();
+    const app = createApp();
     const response = await request(app).post(TOKEN_ENDPOINT).send({
       grant_type: "authorization_code",
       code: "123456",
@@ -414,7 +414,7 @@ describe("/token endpoint tests, invalid client assertion", () => {
       "." +
       fakeSignature();
 
-    const app = await createApp();
+    const app = createApp();
     const response = await request(app).post(TOKEN_ENDPOINT).send({
       grant_type: "authorization_code",
       code: randomUUID(),
@@ -499,7 +499,7 @@ describe("/token endpoint valid client_assertion", () => {
       "ES256"
     );
 
-    const app = await createApp();
+    const app = createApp();
     const response = await request(app).post(TOKEN_ENDPOINT).send({
       grant_type: "authorization_code",
       code: randomUUID(),
@@ -533,7 +533,7 @@ describe("/token endpoint valid client_assertion", () => {
       "ES256"
     );
 
-    const app = await createApp();
+    const app = createApp();
     const response = await request(app).post(TOKEN_ENDPOINT).send({
       grant_type: "authorization_code",
       code: redirectUriMismatchCode,
@@ -567,7 +567,7 @@ describe("/token endpoint valid client_assertion", () => {
       "ES256"
     );
 
-    const app = await createApp();
+    const app = createApp();
     const response = await request(app).post(TOKEN_ENDPOINT).send({
       grant_type: "authorization_code",
       code: knownAuthCode,
@@ -632,7 +632,7 @@ describe("/token endpoint valid client_assertion", () => {
       "RS256"
     );
 
-    const app = await createApp();
+    const app = createApp();
     const response = await request(app).post(TOKEN_ENDPOINT).send({
       grant_type: "authorization_code",
       code: knownAuthCode,


### PR DESCRIPTION
## What

- The simulator now has a `/authorize` endpoint. 
- This responds with a redirect to the valid redirect_uri with a fixed authcode 
- The code and parameters are stored in the AuthCode param store
- The `/authorize` request is parsed and validated against the client config and valid OIDC values
- 

## How to review: 
- Code review commit by commit 
- Look at the tests in `authorise/tests/authorise-get-controller.test.ts` to see the outward API responses for a range of valid and invalid requests 
