### PR TITLE
ATO-1057 : Adds configured errors to ID token 

### DIFF
--- a/src/components/utils/fake-signature.ts
+++ b/src/components/utils/fake-signature.ts
@@ -1,0 +1,7 @@
+import { randomBytes } from "crypto";
+
+export const fakeSignature = (signedJwt: string): string => {
+  const invalidSignature = randomBytes(32).toString("base64url");
+  const [header, payload] = signedJwt.split(".");
+  return [header, payload, invalidSignature].join(".");
+};

--- a/src/components/utils/make-header-invalid.ts
+++ b/src/components/utils/make-header-invalid.ts
@@ -1,0 +1,10 @@
+export const makeHeaderInvalid = (signedJwt: string): string => {
+  const invalidHeader = Buffer.from(
+    JSON.stringify({
+      alg: "HS256",
+    })
+  ).toString("base64url");
+
+  const jwtParts = signedJwt.split(".");
+  return [invalidHeader, jwtParts[1], jwtParts[2]].join(".");
+};

--- a/src/components/utils/tests/fake-signature.test.ts
+++ b/src/components/utils/tests/fake-signature.test.ts
@@ -1,0 +1,19 @@
+import crypto from "crypto";
+import { fakeSignature } from "../fake-signature";
+
+describe("fakeSignature tests", () => {
+  const testToken =
+    "eyJhbGciOiJFUzI1NiIsImtpZCI6ImI5MTYyNjY3LWUwMjUtNGQ5My04YzViLWU1MzhlNmM3OTJhYyJ9.eyJpYXQiOjE3MjY3NDQyNzksImV4cCI6MTcyNjc0NDM5OSwiYXRfaGFzaCI6IktydllHM0xWVlEzcTZ1TVRfVC1Gd3ciLCJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOjllMzc0YjQ3YzRlZjZkZTY1NTFiZTVmMjhkOTdmOWRkIiwiYXVkIjoiZDc2ZGI1Njc2MGNlZGE3Y2FiODc1ZjA4NWM1NGJkMzUiLCJpc3MiOiJodHRwczovL29pZGMuYWNjb3VudC5nb3YudWsiLCJzaWQiOiI1MGE5MDQxYjVkNTdjYjUzNjMyYTBlOTI1OTg2NGI3MSIsInZvdCI6IkNsLkNtIiwibm9uY2UiOiJiZjA1YzM2ZGE5MTIyYTczNzg0Mzk5MjRjMDExYzUxYyIsInZ0bSI6Imh0dHBzOi8vb2lkYy5hY2NvdW50Lmdvdi51ay90cnVzdG1hcmsifQ.qYBYPBU_aebwPgRrmDH5hs4Je3fqNJmGPoPoBnIrGQ-F4aBPYAp2nIP-87w3A04vyMOQ4eckGWUkMaKgpt20tQ";
+
+  it("replaces a signed JWT signature with a random string", () => {
+    jest
+      .spyOn(crypto, "randomBytes")
+      .mockImplementation(() =>
+        Buffer.from("ev5Z6kN4jORG2cMZp-NpEUT_hpvWOOQmGZeu3nAaQUo")
+      );
+
+    expect(fakeSignature(testToken)).toStrictEqual(
+      "eyJhbGciOiJFUzI1NiIsImtpZCI6ImI5MTYyNjY3LWUwMjUtNGQ5My04YzViLWU1MzhlNmM3OTJhYyJ9.eyJpYXQiOjE3MjY3NDQyNzksImV4cCI6MTcyNjc0NDM5OSwiYXRfaGFzaCI6IktydllHM0xWVlEzcTZ1TVRfVC1Gd3ciLCJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOjllMzc0YjQ3YzRlZjZkZTY1NTFiZTVmMjhkOTdmOWRkIiwiYXVkIjoiZDc2ZGI1Njc2MGNlZGE3Y2FiODc1ZjA4NWM1NGJkMzUiLCJpc3MiOiJodHRwczovL29pZGMuYWNjb3VudC5nb3YudWsiLCJzaWQiOiI1MGE5MDQxYjVkNTdjYjUzNjMyYTBlOTI1OTg2NGI3MSIsInZvdCI6IkNsLkNtIiwibm9uY2UiOiJiZjA1YzM2ZGE5MTIyYTczNzg0Mzk5MjRjMDExYzUxYyIsInZ0bSI6Imh0dHBzOi8vb2lkYy5hY2NvdW50Lmdvdi51ay90cnVzdG1hcmsifQ.ZXY1WjZrTjRqT1JHMmNNWnAtTnBFVVRfaHB2V09PUW1HWmV1M25BYVFVbw"
+    );
+  });
+});

--- a/src/components/utils/tests/make-header-invalid.test.ts
+++ b/src/components/utils/tests/make-header-invalid.test.ts
@@ -1,0 +1,17 @@
+import { makeHeaderInvalid } from "../make-header-invalid";
+
+describe("makeHeaderInvalid tests", () => {
+  const testToken =
+    "eyJhbGciOiJFUzI1NiIsImtpZCI6ImI5MTYyNjY3LWUwMjUtNGQ5My04YzViLWU1MzhlNmM3OTJhYyJ9.eyJpYXQiOjE3MjY3NDQyNzksImV4cCI6MTcyNjc0NDM5OSwiYXRfaGFzaCI6IktydllHM0xWVlEzcTZ1TVRfVC1Gd3ciLCJzdWIiOiJ1cm46ZmRjOmdvdi51azoyMDIyOjllMzc0YjQ3YzRlZjZkZTY1NTFiZTVmMjhkOTdmOWRkIiwiYXVkIjoiZDc2ZGI1Njc2MGNlZGE3Y2FiODc1ZjA4NWM1NGJkMzUiLCJpc3MiOiJodHRwczovL29pZGMuYWNjb3VudC5nb3YudWsiLCJzaWQiOiI1MGE5MDQxYjVkNTdjYjUzNjMyYTBlOTI1OTg2NGI3MSIsInZvdCI6IkNsLkNtIiwibm9uY2UiOiJiZjA1YzM2ZGE5MTIyYTczNzg0Mzk5MjRjMDExYzUxYyIsInZ0bSI6Imh0dHBzOi8vb2lkYy5hY2NvdW50Lmdvdi51ay90cnVzdG1hcmsifQ.qYBYPBU_aebwPgRrmDH5hs4Je3fqNJmGPoPoBnIrGQ-F4aBPYAp2nIP-87w3A04vyMOQ4eckGWUkMaKgpt20tQ";
+
+  it("replaces a valid header with an invalid one with an unsupported alg", () => {
+    const jwtWithInvalidHeader = makeHeaderInvalid(testToken);
+    const [header] = jwtWithInvalidHeader.split(".");
+    const parsedHeader = JSON.parse(
+      Buffer.from(header, "base64url").toString()
+    );
+    expect(parsedHeader).toStrictEqual({
+      alg: "HS256",
+    });
+  });
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -68,3 +68,5 @@ export const ID_TOKEN_ERRORS = [
   "NONCE_NOT_MATCHING",
   "INCORRECT_VOT",
 ];
+
+export const INVALID_ISSUER = "https://example.com/identity-provider";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -70,3 +70,4 @@ export const ID_TOKEN_ERRORS = [
 ];
 
 export const INVALID_ISSUER = "https://example.com/identity-provider";
+export const ONE_DAY_IN_SECONDS = 86400;


### PR DESCRIPTION
## What: 
- Our token endpoint can now return invalid responses
- These can be configured after the work done here: https://github.com/govuk-one-login/simulator/pull/105
## Why:
- This will allow RPs to test their error handling for the token endpoint
## Related PRs: 
- Branches off https://github.com/govuk-one-login/simulator/pull/105, so must be merged first 🙂 