### PR TITLE
BAU: Remove docker compose volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,4 @@ services:
       dockerfile: Dockerfile
     ports:
       - "3000:3000"
-    volumes:
-      - ./:/app
     restart: on-failure


### PR DESCRIPTION
This injects the code into the docker environment. This is unnecessary