### PR TITLE
Ato 1010/implement identity for token endpoint

### DIFF
--- a/src/components/token/tests/helper/create-access-token.test.ts
+++ b/src/components/token/tests/helper/create-access-token.test.ts
@@ -10,6 +10,7 @@ import {
   RSA_KEY_ID,
   SESSION_ID,
 } from "../../../../constants";
+import { VectorOfTrust } from "../../../../types/vector-of-trust";
 import { createAccessToken } from "../../helper/create-access-token";
 
 describe("createAccessToken tests", () => {
@@ -38,11 +39,15 @@ describe("createAccessToken tests", () => {
   });
 
   it("returns a signed jwt using RS256", async () => {
+    const vtr: VectorOfTrust = {
+      credentialTrust: "Cl.Cm",
+      levelOfConfidence: "P2",
+    };
     tokenSigningAlgorithmSpy.mockReturnValue("RS256");
     subSpy.mockReturnValue(testSubClaim);
     clientIdSpy.mockReturnValue(testClientId);
 
-    const accessToken = await createAccessToken(["openid"]);
+    const accessToken = await createAccessToken(["openid"], vtr, null);
     const tokenParts = accessToken.split(".");
 
     const header = decodeTokenPart(tokenParts[0]);
@@ -67,11 +72,15 @@ describe("createAccessToken tests", () => {
   });
 
   it("returns a signed jwt using ES256", async () => {
+    const vtr: VectorOfTrust = {
+      credentialTrust: "Cl.Cm",
+      levelOfConfidence: "P2",
+    };
     tokenSigningAlgorithmSpy.mockReturnValue("ES256");
     subSpy.mockReturnValue(testSubClaim);
     clientIdSpy.mockReturnValue(testClientId);
 
-    const accessToken = await createAccessToken(["openid"]);
+    const accessToken = await createAccessToken(["openid"], vtr, null);
     const tokenParts = accessToken.split(".");
 
     const header = decodeTokenPart(tokenParts[0]);

--- a/src/components/token/tests/helper/create-access-token.test.ts
+++ b/src/components/token/tests/helper/create-access-token.test.ts
@@ -39,71 +39,58 @@ describe("createAccessToken tests", () => {
     jest.useRealTimers();
   });
 
-  it("returns a signed jwt using RS256", async () => {
-    const vtr: VectorOfTrust = {
-      credentialTrust: "Cl.Cm",
-      levelOfConfidence: "P2",
-    };
-    tokenSigningAlgorithmSpy.mockReturnValue("RS256");
-    subSpy.mockReturnValue(testSubClaim);
-    clientIdSpy.mockReturnValue(testClientId);
+  test.each<{
+    tokenSigningAlgorithm: "RS256" | "ES256";
+    expectedKeyId: string;
+  }>([
+    {
+      tokenSigningAlgorithm: "RS256",
+      expectedKeyId: RSA_KEY_ID,
+    },
+    {
+      tokenSigningAlgorithm: "ES256",
+      expectedKeyId: EC_KEY_ID,
+    },
+  ])(
+    "returns a signed jwt using $tokenSigningAlgorithm",
+    async ({ tokenSigningAlgorithm, expectedKeyId }) => {
+      const vtr: VectorOfTrust = {
+        credentialTrust: "Cl.Cm",
+        levelOfConfidence: "P2",
+      };
+      tokenSigningAlgorithmSpy.mockReturnValue(tokenSigningAlgorithm);
+      subSpy.mockReturnValue(testSubClaim);
+      clientIdSpy.mockReturnValue(testClientId);
 
-    const accessToken = await createAccessToken(["openid"], vtr, null);
-    const tokenParts = accessToken.split(".");
+      const accessToken = await createAccessToken(
+        ["openid"],
+        vtr,
+        VALID_CLAIMS
+      );
+      const tokenParts = accessToken.split(".");
 
-    const header = decodeTokenPart(tokenParts[0]);
-    const payload = decodeTokenPart(tokenParts[1]);
+      const header = decodeTokenPart(tokenParts[0]);
+      const payload = decodeTokenPart(tokenParts[1]);
 
-    expect(tokenParts.length).toBe(3);
-    expect(header).toStrictEqual({
-      alg: "RS256",
-      kid: RSA_KEY_ID,
-    });
-    expect(payload).toStrictEqual({
-      iat: Math.floor(testTimestamp / 1000),
-      exp: Math.floor(testTimestamp / 1000) + ACCESS_TOKEN_EXPIRY,
-      iss: ISSUER_VALUE,
-      jti: "1234567",
-      client_id: testClientId,
-      sub: testSubClaim,
-      sid: SESSION_ID,
-      scope: ["openid"],
-    });
-    expect(typeof tokenParts[2]).toBe("string");
-  });
-
-  it("returns a signed jwt using ES256", async () => {
-    const vtr: VectorOfTrust = {
-      credentialTrust: "Cl.Cm",
-      levelOfConfidence: "P2",
-    };
-    tokenSigningAlgorithmSpy.mockReturnValue("ES256");
-    subSpy.mockReturnValue(testSubClaim);
-    clientIdSpy.mockReturnValue(testClientId);
-
-    const accessToken = await createAccessToken(["openid"], vtr, null);
-    const tokenParts = accessToken.split(".");
-
-    const header = decodeTokenPart(tokenParts[0]);
-    const payload = decodeTokenPart(tokenParts[1]);
-
-    expect(tokenParts.length).toStrictEqual(3);
-    expect(header).toStrictEqual({
-      alg: "ES256",
-      kid: EC_KEY_ID,
-    });
-    expect(payload).toStrictEqual({
-      iat: Math.floor(testTimestamp / 1000),
-      exp: Math.floor(testTimestamp / 1000) + ACCESS_TOKEN_EXPIRY,
-      iss: ISSUER_VALUE,
-      jti: "1234567",
-      client_id: testClientId,
-      sub: testSubClaim,
-      sid: SESSION_ID,
-      scope: ["openid"],
-    });
-    expect(typeof tokenParts[2]).toBe("string");
-  });
+      expect(tokenParts.length).toBe(3);
+      expect(header).toStrictEqual({
+        alg: tokenSigningAlgorithm,
+        kid: expectedKeyId,
+      });
+      expect(payload).toStrictEqual({
+        iat: Math.floor(testTimestamp / 1000),
+        exp: Math.floor(testTimestamp / 1000) + ACCESS_TOKEN_EXPIRY,
+        iss: ISSUER_VALUE,
+        jti: "1234567",
+        client_id: testClientId,
+        sub: testSubClaim,
+        sid: SESSION_ID,
+        scope: ["openid"],
+        claims: VALID_CLAIMS,
+      });
+      expect(typeof tokenParts[2]).toBe("string");
+    }
+  );
 
   it("does not contain any claims if no claims were given", async () => {
     const vtr: VectorOfTrust = {

--- a/src/components/token/token-controller.ts
+++ b/src/components/token/token-controller.ts
@@ -49,7 +49,11 @@ export const tokenController = async (
       });
     }
 
-    const accessToken = await createAccessToken(authCodeParams.scopes);
+    const accessToken = await createAccessToken(
+      authCodeParams.scopes,
+      authCodeParams.vtr,
+      authCodeParams.claims
+    );
     const idToken = await createIdToken(authCodeParams, accessToken);
 
     res.status(200).json({

--- a/src/types/access-token-claims.ts
+++ b/src/types/access-token-claims.ts
@@ -7,4 +7,5 @@ export type AccessTokenClaims = {
   sub: string;
   sid: string;
   scope: string[];
+  claims?: string[] | null;
 };


### PR DESCRIPTION
## ATO-1010: implement identity for token endpoint

Adds: 
- Adds claims to access token if they are requested and auth request included non-null identity vector

Work done by @GHSwallow 