### PR TITLE
ATO-1055 store access token

### DIFF
--- a/src/components/config/tests/config-controller.test.ts
+++ b/src/components/config/tests/config-controller.test.ts
@@ -150,7 +150,7 @@ describe("Integration: Config POST", () => {
     );
     expect(config.getClientLoCs()).toEqual(TEST_CLIENT_LOCS);
     expect(config.getSub()).toEqual(TEST_SUB);
-    expect(config.getEmail()).toEqual("john.smith@gmail.com");
+    expect(config.getEmail()).toEqual("test@example.com");
     expect(config.getEmailVerified()).toEqual(TEST_EMAIL_VERIFIED);
     expect(config.getPhoneNumber()).toEqual(TEST_PHONE_NUMBER);
     expect(config.getPhoneNumberVerified()).toEqual(true);
@@ -195,7 +195,7 @@ describe("Integration: Config POST", () => {
     );
     expect(config.getClientLoCs()).toEqual(TEST_CLIENT_LOCS);
     expect(config.getSub()).toEqual(TEST_SUB);
-    expect(config.getEmail()).toEqual("john.smith@gmail.com");
+    expect(config.getEmail()).toEqual("test@example.com");
     expect(config.getEmailVerified()).toEqual(TEST_EMAIL_VERIFIED);
     expect(config.getPhoneNumber()).toEqual(TEST_PHONE_NUMBER);
     expect(config.getPhoneNumberVerified()).toEqual(true);

--- a/src/components/token/token-controller.ts
+++ b/src/components/token/token-controller.ts
@@ -56,6 +56,11 @@ export const tokenController = async (
     );
     const idToken = await createIdToken(authCodeParams, accessToken);
 
+    config.addToAccessTokenStore(
+      `${config.getClientId()}.${config.getSub()}`,
+      accessToken
+    );
+
     res.status(200).json({
       access_token: accessToken,
       token_type: "Bearer",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,7 @@
+import {
+  AccessTokenStore,
+  AccessTokenStoreKey,
+} from "./types/access-token-store";
 import AuthRequestParameters from "./types/auth-request-parameters";
 import ClientConfiguration from "./types/client-configuration";
 import ResponseConfiguration from "./types/response-configuration";
@@ -14,6 +18,7 @@ export class Config {
   private responseConfiguration: ResponseConfiguration;
   private errorConfiguration: ErrorConfiguration;
   private authCodeRequestParamsStore: Record<string, AuthRequestParameters>;
+  private accessTokenStore: AccessTokenStore;
 
   private constructor() {
     const defaultPublicKey = `-----BEGIN PUBLIC KEY-----
@@ -67,6 +72,7 @@ CQIDAQAB
     };
 
     this.authCodeRequestParamsStore = {};
+    this.accessTokenStore = {};
   }
 
   public static getInstance(): Config {
@@ -202,6 +208,22 @@ CQIDAQAB
 
   public deleteFromAuthCodeRequestParamsStore(authCode: string): void {
     delete this.authCodeRequestParamsStore[authCode];
+  }
+
+  public getAccessTokensFromStore(
+    clientIdSub: AccessTokenStoreKey
+  ): string[] | undefined {
+    return this.accessTokenStore[clientIdSub];
+  }
+
+  public addToAccessTokenStore(
+    clientIdSub: AccessTokenStoreKey,
+    accessToken: string
+  ): void {
+    this.accessTokenStore[clientIdSub] = [
+      ...(this.accessTokenStore[clientIdSub] ?? []),
+      accessToken,
+    ];
   }
 
   public getCoreIdentityErrors(): CoreIdentityError[] {

--- a/src/types/access-token-store.ts
+++ b/src/types/access-token-store.ts
@@ -1,0 +1,5 @@
+export type AccessTokenStoreKey = `${string}.${string}`;
+
+export type AccessTokenStore = {
+  [clientIdSub: AccessTokenStoreKey]: string[];
+};

--- a/src/validators/user-info-request-validator.ts
+++ b/src/validators/user-info-request-validator.ts
@@ -15,26 +15,28 @@ export const userInfoRequestValidator = async (
       error: UserInfoRequestError;
     }
 > => {
-  const accessToken = userInfoRequestHeaders.authorization;
-  if (!accessToken) {
+  const authorisationHeader = userInfoRequestHeaders.authorization;
+  if (!authorisationHeader) {
     logger.warn("Missing authorisation header.");
     return { valid: false, error: UserInfoRequestError.MISSING_TOKEN };
   }
 
   let match;
   try {
-    match = /^Bearer (?<token>.*)$/.exec(accessToken);
+    match = /^Bearer (?<token>.*)$/.exec(authorisationHeader);
   } catch (error) {
     logger.error("Error parsing authorisation header.", error);
     return { valid: false, error: UserInfoRequestError.INVALID_TOKEN };
   }
 
-  if (!match?.groups?.token) {
+  const accessToken = match?.groups?.token;
+
+  if (!accessToken) {
     logger.warn("Failed to parse token in authorisation header.");
     return { valid: false, error: UserInfoRequestError.INVALID_TOKEN };
   }
 
-  const jwtResult = await signedJwtValidator(match.groups.token);
+  const jwtResult = await signedJwtValidator(accessToken);
   if (!jwtResult.valid) {
     logger.warn("Failed to verify token signature.");
     return { valid: false, error: UserInfoRequestError.INVALID_TOKEN };
@@ -63,6 +65,15 @@ export const userInfoRequestValidator = async (
       `Scopes "[${scope}]" don't match expected values "[${config_scopes}]".`
     );
     return { valid: false, error: UserInfoRequestError.INVALID_SCOPE };
+  }
+
+  const accessTokensForClient = config.getAccessTokensFromStore(
+    `${config_client_id}.${config.getSub()}`
+  );
+
+  if (!accessTokensForClient?.includes(accessToken)) {
+    logger.warn("Access token not found in access token store");
+    return { valid: false, error: UserInfoRequestError.INVALID_TOKEN };
   }
 
   return { valid: true };

--- a/src/validators/user-info-request-validator.ts
+++ b/src/validators/user-info-request-validator.ts
@@ -21,14 +21,7 @@ export const userInfoRequestValidator = async (
     return { valid: false, error: UserInfoRequestError.MISSING_TOKEN };
   }
 
-  let match;
-  try {
-    match = /^Bearer (?<token>.*)$/.exec(authorisationHeader);
-  } catch (error) {
-    logger.error("Error parsing authorisation header.", error);
-    return { valid: false, error: UserInfoRequestError.INVALID_TOKEN };
-  }
-
+  const match = /^Bearer (?<token>.*)$/.exec(authorisationHeader);
   const accessToken = match?.groups?.token;
 
   if (!accessToken) {

--- a/tests/integration/user-info.test.ts
+++ b/tests/integration/user-info.test.ts
@@ -10,6 +10,8 @@ import { UserInfo } from "../../src/types/user-info";
 
 const USER_INFO_ENDPOINT = "/userinfo";
 const KNOWN_CLIENT_ID = "d76db56760ceda7cab875f085c54bd35";
+const KNOWN_SUB_CLAIM =
+  "urn:fdc:gov.uk:2022:56P4CMsGh_02YOlWpd8PAOI-2sVlB2nsNU7mcLZYhYw=";
 const INVALID_EC_PRIVATE_TOKEN_SIGNING_KEY =
   "-----BEGIN PRIVATE KEY-----MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgnEpemWfQ6m2Fxo6ENP13NkocvvrAKHc/IWbC+jSOc/uhRANCAARcsKXyN+lhvtj4KzR1QNYqHE2OWFK8W3dap/x1mO/OYN6D6f9KWLXy6+Nrnp11SB5Qj9IMUWPQUBolJLSaxhBI-----END PRIVATE KEY-----";
 const AUTHORIZATION_HEADER_KEY: string = "authorization";
@@ -29,10 +31,10 @@ describe("/userinfo endpoint tests, invalid request", () => {
   it("returns a invalid_token error for badly formed header", async () => {
     await setupClientConfig(KNOWN_CLIENT_ID, ["openid", "email", "phone"]);
     const app = createApp();
-    const tokenHeader = "invalid-authentication-header";
+    const accessToken = "invalid-access-token";
     const response = await request(app)
       .get(USER_INFO_ENDPOINT)
-      .set(AUTHORIZATION_HEADER_KEY, tokenHeader);
+      .set(AUTHORIZATION_HEADER_KEY, `Bearer ${accessToken}`);
 
     expect(response.status).toBe(401);
     expect(response.header[AUTHENTICATE_HEADER_KEY]).toBe(
@@ -44,7 +46,7 @@ describe("/userinfo endpoint tests, invalid request", () => {
   it("returns an invalid_scope error for invalid scope", async () => {
     await setupClientConfig(KNOWN_CLIENT_ID, ["openid", "email", "phone"]);
     const app = createApp();
-    const tokenHeader = await generateTokenHeader(
+    const accessToken = await createAccessToken(
       ISSUER_VALUE,
       KNOWN_CLIENT_ID,
       ["invalid-scope"],
@@ -52,7 +54,7 @@ describe("/userinfo endpoint tests, invalid request", () => {
     );
     const response = await request(app)
       .get(USER_INFO_ENDPOINT)
-      .set(AUTHORIZATION_HEADER_KEY, tokenHeader);
+      .set(AUTHORIZATION_HEADER_KEY, `Bearer ${accessToken}`);
 
     expect(response.status).toBe(401);
     expect(response.header[AUTHENTICATE_HEADER_KEY]).toBe(
@@ -64,7 +66,7 @@ describe("/userinfo endpoint tests, invalid request", () => {
   it("returns an invalid_scope error for unexpected scope", async () => {
     await setupClientConfig(KNOWN_CLIENT_ID, ["openid", "email"]);
     const app = createApp();
-    const tokenHeader = await generateTokenHeader(
+    const accessToken = await createAccessToken(
       ISSUER_VALUE,
       KNOWN_CLIENT_ID,
       ["openid", "phone"],
@@ -72,7 +74,7 @@ describe("/userinfo endpoint tests, invalid request", () => {
     );
     const response = await request(app)
       .get(USER_INFO_ENDPOINT)
-      .set(AUTHORIZATION_HEADER_KEY, tokenHeader);
+      .set(AUTHORIZATION_HEADER_KEY, `Bearer ${accessToken}`);
 
     expect(response.status).toBe(401);
     expect(response.header[AUTHENTICATE_HEADER_KEY]).toBe(
@@ -84,7 +86,7 @@ describe("/userinfo endpoint tests, invalid request", () => {
   it("returns an invalid_token error for missing client id", async () => {
     await setupClientConfig(KNOWN_CLIENT_ID, ["openid", "email", "phone"]);
     const app = createApp();
-    const tokenHeader = await generateTokenHeader(
+    const accessToken = await createAccessToken(
       ISSUER_VALUE,
       null,
       ["openid", "email", "phone"],
@@ -92,7 +94,7 @@ describe("/userinfo endpoint tests, invalid request", () => {
     );
     const response = await request(app)
       .get(USER_INFO_ENDPOINT)
-      .set(AUTHORIZATION_HEADER_KEY, tokenHeader);
+      .set(AUTHORIZATION_HEADER_KEY, `Bearer ${accessToken}`);
 
     expect(response.status).toBe(401);
     expect(response.header[AUTHENTICATE_HEADER_KEY]).toBe(
@@ -104,7 +106,7 @@ describe("/userinfo endpoint tests, invalid request", () => {
   it("returns an invalid_token error for unexpected client id", async () => {
     await setupClientConfig(KNOWN_CLIENT_ID, ["openid", "email", "phone"]);
     const app = createApp();
-    const tokenHeader = await generateTokenHeader(
+    const accessToken = await createAccessToken(
       ISSUER_VALUE,
       "unexpected-client-id",
       ["openid", "email", "phone"],
@@ -112,7 +114,7 @@ describe("/userinfo endpoint tests, invalid request", () => {
     );
     const response = await request(app)
       .get(USER_INFO_ENDPOINT)
-      .set(AUTHORIZATION_HEADER_KEY, tokenHeader);
+      .set(AUTHORIZATION_HEADER_KEY, `Bearer ${accessToken}`);
 
     expect(response.status).toBe(401);
     expect(response.header[AUTHENTICATE_HEADER_KEY]).toBe(
@@ -124,7 +126,7 @@ describe("/userinfo endpoint tests, invalid request", () => {
   it("returns an invalid_token error for expired token", async () => {
     await setupClientConfig(KNOWN_CLIENT_ID, ["openid", "email", "phone"]);
     const app = createApp();
-    const tokenHeader = await generateTokenHeader(
+    const accessToken = await createAccessToken(
       ISSUER_VALUE,
       KNOWN_CLIENT_ID,
       ["openid", "email", "phone"],
@@ -133,7 +135,7 @@ describe("/userinfo endpoint tests, invalid request", () => {
     );
     const response = await request(app)
       .get(USER_INFO_ENDPOINT)
-      .set(AUTHORIZATION_HEADER_KEY, tokenHeader);
+      .set(AUTHORIZATION_HEADER_KEY, `Bearer ${accessToken}`);
 
     expect(response.status).toBe(401);
     expect(response.header[AUTHENTICATE_HEADER_KEY]).toBe(
@@ -145,7 +147,7 @@ describe("/userinfo endpoint tests, invalid request", () => {
   it("returns an invalid_token error for invalid signature", async () => {
     await setupClientConfig(KNOWN_CLIENT_ID, ["openid", "email", "phone"]);
     const app = createApp();
-    const tokenHeader = await generateTokenHeader(
+    const accessToken = await createAccessToken(
       ISSUER_VALUE,
       KNOWN_CLIENT_ID,
       ["openid", "email", "phone"],
@@ -153,7 +155,7 @@ describe("/userinfo endpoint tests, invalid request", () => {
     );
     const response = await request(app)
       .get(USER_INFO_ENDPOINT)
-      .set(AUTHORIZATION_HEADER_KEY, tokenHeader);
+      .set(AUTHORIZATION_HEADER_KEY, `Bearer ${accessToken}`);
 
     expect(response.status).toBe(401);
     expect(response.header[AUTHENTICATE_HEADER_KEY]).toBe(
@@ -165,7 +167,7 @@ describe("/userinfo endpoint tests, invalid request", () => {
   it("returns an invalid_token error for unexpected issuer", async () => {
     await setupClientConfig(KNOWN_CLIENT_ID, ["openid", "email", "phone"]);
     const app = createApp();
-    const tokenHeader = await generateTokenHeader(
+    const accessToken = await createAccessToken(
       "unexpected-issuer",
       KNOWN_CLIENT_ID,
       ["openid", "email", "phone"],
@@ -173,7 +175,7 @@ describe("/userinfo endpoint tests, invalid request", () => {
     );
     const response = await request(app)
       .get(USER_INFO_ENDPOINT)
-      .set(AUTHORIZATION_HEADER_KEY, tokenHeader);
+      .set(AUTHORIZATION_HEADER_KEY, `Bearer ${accessToken}`);
 
     expect(response.status).toBe(401);
     expect(response.header[AUTHENTICATE_HEADER_KEY]).toBe(
@@ -182,25 +184,69 @@ describe("/userinfo endpoint tests, invalid request", () => {
     expect(response.body).toStrictEqual({});
   });
 
-  it("returns expected user info for valid token", async () => {
+  it("returns an invalid token error if the access token is not in the accessToken store", async () => {
     await setupClientConfig(KNOWN_CLIENT_ID, ["openid", "email", "phone"]);
-    const app = createApp();
-    const tokenHeader = await generateTokenHeader(
+    const accessToken = await createAccessToken(
       ISSUER_VALUE,
       KNOWN_CLIENT_ID,
       ["openid", "email", "phone"],
       EC_PRIVATE_TOKEN_SIGNING_KEY
     );
+    const app = createApp();
     const response = await request(app)
       .get(USER_INFO_ENDPOINT)
-      .set(AUTHORIZATION_HEADER_KEY, tokenHeader);
+      .set(AUTHORIZATION_HEADER_KEY, `Bearer ${accessToken}`);
+
+    expect(response.status).toBe(401);
+    expect(response.header[AUTHENTICATE_HEADER_KEY]).toBe(
+      'Bearer error="invalid_token", error_description="Invalid access token"'
+    );
+  });
+
+  it("returns an invalid token error if the access does not match the one in the access token store", async () => {
+    await setupClientConfig(KNOWN_CLIENT_ID, ["openid", "email", "phone"]);
+    addAccessTokenToStore(
+      KNOWN_CLIENT_ID,
+      KNOWN_SUB_CLAIM,
+      "not-the-same-access-token"
+    );
+    const accessToken = await createAccessToken(
+      ISSUER_VALUE,
+      KNOWN_CLIENT_ID,
+      ["openid", "email", "phone"],
+      EC_PRIVATE_TOKEN_SIGNING_KEY
+    );
+    const app = createApp();
+    const response = await request(app)
+      .get(USER_INFO_ENDPOINT)
+      .set(AUTHORIZATION_HEADER_KEY, `Bearer ${accessToken}`);
+
+    expect(response.status).toBe(401);
+    expect(response.header[AUTHENTICATE_HEADER_KEY]).toBe(
+      'Bearer error="invalid_token", error_description="Invalid access token"'
+    );
+  });
+
+  it("returns expected user info for valid token", async () => {
+    await setupClientConfig(KNOWN_CLIENT_ID, ["openid", "email", "phone"]);
+    const accessToken = await createAccessToken(
+      ISSUER_VALUE,
+      KNOWN_CLIENT_ID,
+      ["openid", "email", "phone"],
+      EC_PRIVATE_TOKEN_SIGNING_KEY
+    );
+    addAccessTokenToStore(KNOWN_CLIENT_ID, KNOWN_SUB_CLAIM, accessToken);
+    const app = createApp();
+    const response = await request(app)
+      .get(USER_INFO_ENDPOINT)
+      .set(AUTHORIZATION_HEADER_KEY, `Bearer ${accessToken}`);
 
     const expectedUserInfo: UserInfo = {
       email: "test@example.com",
       email_verified: true,
       phone_number: "07123456789",
       phone_number_verified: true,
-      sub: "urn:fdc:gov.uk:2022:56P4CMsGh_02YOlWpd8PAOI-2sVlB2nsNU7mcLZYhYw=",
+      sub: KNOWN_SUB_CLAIM,
     };
 
     expect(response.status).toBe(200);
@@ -209,7 +255,7 @@ describe("/userinfo endpoint tests, invalid request", () => {
   });
 });
 
-async function generateTokenHeader(
+async function createAccessToken(
   issuer: string,
   clientId: string | null,
   scopes: string[],
@@ -228,11 +274,19 @@ async function generateTokenHeader(
     await importPKCS8(privateKey, "EC")
   );
 
-  return `Bearer ${signedJwt}`;
+  return signedJwt;
 }
 
 const setupClientConfig = async (clientId: string, scopes: string[]) => {
   process.env.CLIENT_ID = clientId;
   process.env.SCOPES = scopes.join(",");
   Config.resetInstance();
+};
+
+const addAccessTokenToStore = (
+  clientId: string,
+  sub: string,
+  accessToken: string
+): void => {
+  Config.getInstance().addToAccessTokenStore(`${clientId}.${sub}`, accessToken);
 };

--- a/tests/integration/user-info.test.ts
+++ b/tests/integration/user-info.test.ts
@@ -43,6 +43,22 @@ describe("/userinfo endpoint tests, invalid request", () => {
     expect(response.body).toStrictEqual({});
   });
 
+  it("returns an invalid_token response for a header without Bearer ", async () => {
+    await setupClientConfig(KNOWN_CLIENT_ID, ["openid", "email", "phone"]);
+    const app = createApp();
+    const accessToken =
+      "eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    const response = await request(app)
+      .get(USER_INFO_ENDPOINT)
+      .set(AUTHORIZATION_HEADER_KEY, accessToken);
+
+    expect(response.status).toBe(401);
+    expect(response.header[AUTHENTICATE_HEADER_KEY]).toBe(
+      'Bearer error="invalid_token", error_description="Invalid access token"'
+    );
+    expect(response.body).toStrictEqual({});
+  });
+
   it("returns an invalid_scope error for invalid scope", async () => {
     await setupClientConfig(KNOWN_CLIENT_ID, ["openid", "email", "phone"]);
     const app = createApp();


### PR DESCRIPTION
## What: 
- We now have an in memory store for the access tokens we issue from the `/token` endpoint
- This is a key-value pair store where the key is `clientId.sub`
- We now store the tokens once we issue them in the token endpoint 
- I've added the same checks we do in the real `/userinfo` endpoint to see if the access token included in the request is in the store and matches
- Some very small renaming/refactoring in the last commit

## How to review: 
- Code review commit by commit 