### PR TITLE
ATO-1058: Add Support For Core Identity Error Scenarios

### DIFF
--- a/tests/integration/helper/decode-jwt-no-verify.ts
+++ b/tests/integration/helper/decode-jwt-no-verify.ts
@@ -1,0 +1,14 @@
+export const decodeJwtNoVerify = (
+  signedJwt: string
+): {
+  payload: Record<string, string>;
+  protectedHeader: Record<string, string>;
+} => {
+  const [headerPart, payloadPart] = signedJwt.split(".");
+  const payload = decodeTokenPart(payloadPart);
+  const protectedHeader = decodeTokenPart(headerPart);
+  return { payload, protectedHeader };
+};
+
+const decodeTokenPart = (part: string): Record<string, string> =>
+  JSON.parse(Buffer.from(part, "base64url").toString());


### PR DESCRIPTION
- Added support for core identity error scenarios
- Factored out common _decodeJwtNoVerify_ helper