### PR TITLE
ATO-1078: remove not supported signing keys

### DIFF
--- a/src/parse/parse-token-request.ts
+++ b/src/parse/parse-token-request.ts
@@ -267,17 +267,7 @@ const parseClientAssertion = (
 
   if (
     !header.alg ||
-    ![
-      "RS256",
-      "RS384",
-      "RS512",
-      "ES256",
-      "ES384",
-      "ES512",
-      "PS256",
-      "PS384",
-      "PS512",
-    ].includes(header.alg)
+    !["RS256", "RS384", "RS512", "PS256", "PS384", "PS512"].includes(header.alg)
   ) {
     throw new ParseTokenRequestError(
       "Invalid client_assertion JWT: The client assertion JWT must be RSA or ECDSA-signed (RS256, RS384, RS512, PS256, PS384, PS512, ES256, ES384 or ES512)"


### PR DESCRIPTION
Removes the unsupported ES keys from token request parser.

The error message has not been updated (ie still explains that ES keys are ok), as this is still the error message in OL.