### PR TITLE
BAU: Fix VTR logic for P0 cases

### DIFF
--- a/src/validators/tests/vtr-validator.test.ts
+++ b/src/validators/tests/vtr-validator.test.ts
@@ -220,4 +220,21 @@ describe("vtrValidator tests", () => {
       },
     ]);
   });
+
+  it("handles an omitted LOC but any credential trust", () => {
+    levelOfConfidenceSpy.mockReturnValue(["P0"]);
+
+    expect(
+      vtrValidator('["Cl.Cm", "Cl"]', config, state, redirectUri)
+    ).toStrictEqual([
+      {
+        levelOfConfidence: null,
+        credentialTrust: "Cl.Cm",
+      },
+      {
+        levelOfConfidence: null,
+        credentialTrust: "Cl",
+      },
+    ]);
+  });
 });

--- a/src/validators/tests/vtr-validator.test.ts
+++ b/src/validators/tests/vtr-validator.test.ts
@@ -203,4 +203,21 @@ describe("vtrValidator tests", () => {
       },
     ]);
   });
+
+  it("allows P0 with any credential trust level", () => {
+    levelOfConfidenceSpy.mockReturnValue(["P0"]);
+
+    expect(
+      vtrValidator('["Cl.Cm.P0", "Cl.P0"]', config, state, redirectUri)
+    ).toStrictEqual([
+      {
+        levelOfConfidence: "P0",
+        credentialTrust: "Cl.Cm",
+      },
+      {
+        levelOfConfidence: "P0",
+        credentialTrust: "Cl",
+      },
+    ]);
+  });
 });

--- a/src/validators/vtr-validator.ts
+++ b/src/validators/vtr-validator.ts
@@ -97,11 +97,12 @@ const parseSingleVtr = (singleVtr: string): VectorOfTrust => {
     levelOfConfidence: providedLevelsOfConfidence[0] ?? null,
   };
 
-  if (
-    (parsedVtr.levelOfConfidence !== null ||
-      parsedVtr.levelOfConfidence !== "P0") &&
-    parsedVtr.credentialTrust !== "Cl.Cm"
-  ) {
+  const credentialTrustIsNotMedium = parsedVtr.credentialTrust !== "Cl.Cm";
+  const identityBeenRequested =
+    parsedVtr.levelOfConfidence === "P1" ||
+    parsedVtr.levelOfConfidence === "P2";
+
+  if (identityBeenRequested && credentialTrustIsNotMedium) {
     throw new Error(
       "Non zero identity confidence must require at least Cl.Cm credential trust"
     );


### PR DESCRIPTION
## What:
- Due to a bug in the logic, the simulator would reject P0 with a low credential trust level as invalid. This is incorrect and the functionality has now been updated to correct this.

## How to review: 
- Code review commit by commit 
- Look at the new test to ensure we've covered all the cases and fixed the bug
