### PR TITLE
BAU: Fix tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,6 @@
     "baseUrl": ".",
     "typeRoots": ["@types", "node_modules/@types"],
   },
-  "include": ["src/**/*.ts",
-    "tests/acceptance/micro-rp/*.ts"
-  ],
+  "include": ["src/**/*.ts"],
   "exclude": ["coverage", "src/**/**/tests"]
 }


### PR DESCRIPTION
TS was compiling the micro rp into the normal dist folder, which means the simulator was not compliled where node expected it to be