### PR TITLE
ATO-1292: add get config endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ Parameters provided as environment variables that are parsed as an array should 
 
 Where values are not provided for the configuration, [default values](#default-configuration-values) will be used. Some provided configuration fields may be ignored if they are not valid.
 
+### Getting the configuration:
+To get the current configuration of the simulator, a GET request can be made to the `/config` endpoint. This returns the client configuration, response configuration and error configuration, as well as the url the simulator is running on, in the body of the response.
+
 ### Client Configuration
 
 The table below describes the different fields for the client configuration. When updating the client config using the `/config` endpoint, the following JSON structure is required in the request body:

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,6 +11,7 @@ import { generateConfigRequestPropertyValidators } from "./types/config-request"
 import { body, checkExact } from "express-validator";
 import { didController } from "./components/did/did-controller";
 import { logoutController } from "./components/logout/logout-controller";
+import { getConfigController } from "./components/config/get-config-controller";
 
 const createApp = (): Application => {
   const app: Express = express();
@@ -32,6 +33,7 @@ const createApp = (): Application => {
     body().isObject(),
     configController
   );
+  app.get("/config", getConfigController);
   app.post("/token", tokenController);
   app.get("/userinfo", userInfoController);
   app.get("/trustmark", trustmarkController);

--- a/src/components/config/get-config-controller.ts
+++ b/src/components/config/get-config-controller.ts
@@ -1,0 +1,15 @@
+import { Request, Response } from "express";
+import { Config } from "../../config";
+
+export const getConfigController = (req: Request, res: Response): void => {
+  const config = Config.getInstance();
+  const body = {
+    clientConfiguration: config.getClientConfiguration(),
+    errorConfiguration: config.getErrorConfiguration(),
+    responseConfiguration: config.getResponseConfiguration(),
+    simulatorUrl: Config.getInstance().getSimulatorUrl(),
+  };
+  res.header("Content-Type", "application/json");
+  res.status(200);
+  res.send(body);
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -146,6 +146,10 @@ CQIDAQAB
     Config.instance = new Config();
   }
 
+  public getClientConfiguration(): ClientConfiguration {
+    return this.clientConfiguration;
+  }
+
   public getClientId(): string {
     return this.clientConfiguration.clientId!;
   }
@@ -219,6 +223,10 @@ CQIDAQAB
 
   public setClientLoCs(clientLoCs: string[]): void {
     this.clientConfiguration.clientLoCs = clientLoCs;
+  }
+
+  public getResponseConfiguration(): ResponseConfiguration {
+    return this.responseConfiguration;
   }
 
   public getSub(): string {
@@ -354,6 +362,10 @@ CQIDAQAB
       ...(this.accessTokenStore[clientIdSub] ?? []),
       accessToken,
     ];
+  }
+
+  public getErrorConfiguration(): ErrorConfiguration {
+    return this.errorConfiguration;
   }
 
   public getCoreIdentityErrors(): CoreIdentityError[] {

--- a/tests/integration/get-config.test.ts
+++ b/tests/integration/get-config.test.ts
@@ -1,0 +1,19 @@
+import request from "supertest";
+import { createApp } from "../../src/app";
+import { Config } from "../../src/config";
+
+test("returns 200 response with current configuration", async () => {
+  const app = createApp();
+
+  const response = await request(app).get("/config");
+
+  expect(response.status).toEqual(200);
+  const config = Config.getInstance();
+  const expectedBody = {
+    clientConfiguration: config.getClientConfiguration(),
+    responseConfiguration: config.getResponseConfiguration(),
+    errorConfiguration: config.getErrorConfiguration(),
+    simulatorUrl: config.getSimulatorUrl(),
+  };
+  expect(response.body).toEqual(expectedBody);
+});


### PR DESCRIPTION
## What
Adds a `get` for the `/config` endpoint, which returns the current configuration of the simulator. It returns 
- clientConfiguration
- errorConfiguration
- responseConfiguration
- simulatorUrl

in the body of the response.

it does not return
- authCodeRequestParamsStore
- accessTokenStore