### PR TITLE
ATO-1443: add controller to submit form

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,7 @@ import { body, checkExact } from "express-validator";
 import { didController } from "./components/did/did-controller";
 import { logoutController } from "./components/logout/logout-controller";
 import { getConfigController } from "./components/config/get-config-controller";
+import { formSubmitController } from "./components/form-submit/form-submit-controller";
 
 const createApp = (): Application => {
   const app: Express = express();
@@ -44,6 +45,7 @@ const createApp = (): Application => {
   });
   app.get("/.well-known/did.json", didController);
   app.get("/logout", logoutController);
+  app.post("/form-submit", formSubmitController);
 
   return app;
 };

--- a/src/components/authorise/authorise-get-controller.ts
+++ b/src/components/authorise/authorise-get-controller.ts
@@ -76,19 +76,26 @@ export const authoriseController = async (
     }
 
     const authCode = generateAuthCode();
-
-    if (config.isInteractiveModeEnabled()) {
-      res.send(renderResponseConfigFrom(authCode));
-      return;
-    }
-
-    config.addToAuthCodeRequestParamsStore(authCode, {
+    const authRequestParams = {
       claims: parsedAuthRequest.claims,
       nonce: parsedAuthRequest.nonce,
       redirectUri: parsedAuthRequest.redirect_uri,
       scopes: parsedAuthRequest.scope,
       vtr: (parsedAuthRequest.vtr as VectorOfTrust[])[0],
-    });
+    };
+
+    if (config.isInteractiveModeEnabled()) {
+      res.send(
+        renderResponseConfigFrom(
+          authCode,
+          authRequestParams,
+          parsedAuthRequest.state
+        )
+      );
+      return;
+    }
+
+    config.addToAuthCodeRequestParamsStore(authCode, authRequestParams);
 
     res.redirect(
       `${parsedAuthRequest.redirect_uri}?code=${authCode}&state=${parsedAuthRequest.state}`

--- a/src/components/form-submit/form-submit-controller.ts
+++ b/src/components/form-submit/form-submit-controller.ts
@@ -1,0 +1,37 @@
+import { Request, Response } from "express";
+import { Config } from "../../config";
+import { base64url } from "jose";
+import AuthRequestParameters from "src/types/auth-request-parameters";
+import ResponseConfiguration from "src/types/response-configuration";
+
+export const formSubmitController = (req: Request, res: Response): void => {
+  const config = Config.getInstance();
+  const formBody = req.body;
+  const authCode = formBody.authCode;
+  const authRequestParams: AuthRequestParameters = JSON.parse(
+    Buffer.from(base64url.decode(formBody.authRequestParams)).toString()
+  );
+
+  const responseConfiguration: ResponseConfiguration = {
+    sub: formBody.sub,
+    email: formBody.email,
+    emailVerified: formBody.emailVerified === "true",
+    phoneNumber: formBody.phoneNumber,
+    phoneNumberVerified: formBody.phoneNumberVerified === "true",
+    maxLoCAchieved: formBody.maxLoCAchieved,
+    coreIdentityVerifiableCredentials:
+      formBody.coreIdentityVerifiableCredentials,
+    passportDetails: formBody.passportDetails,
+    drivingPermitDetails: formBody.drivingPermitDetails,
+    postalAddressDetails: formBody.postalAddressDetails,
+    returnCodes: formBody.returnCodes,
+  };
+
+  config.addToAuthCodeRequestParamsStore(authCode, {
+    ...authRequestParams,
+    responseConfiguration,
+  });
+  res.redirect(
+    `${authRequestParams.redirectUri}?code=${formBody.authCode}&state=${formBody.state}`
+  );
+};

--- a/src/components/utils/form/render-response-config-form.ts
+++ b/src/components/utils/form/render-response-config-form.ts
@@ -1,12 +1,20 @@
+import AuthRequestParameters from "src/types/auth-request-parameters";
 import { govukStyles } from "./gov-uk-styles";
+import { base64url } from "jose";
 
-//ATO-1443: Determine endpoint for form submission
+//The base64 encoding here looks weird but it's done to escape
+// '/' chars in the html which stop the value being rendered
+// correctly
 const mainContent = (
-  authcode: string
+  authcode: string,
+  authRequest: AuthRequestParameters,
+  state: string
 ) => `<h1 class="govuk-heading-l">Enter response Configuration</h1>
 <p class="govuk-body">Use this form to submit the user info response configuration for this request.</p>
-<form action="/tbd" method="post">
+<form action="/form-submit" method="post">
     <input type="hidden" name="authCode" value="${authcode}"/>
+    <input type="hidden" name="authRequestParams" value="${base64url.encode(Buffer.from(JSON.stringify(authRequest)))}"/>
+    <input type="hidden" name="state" value="${state}"/>
     <dl class="govuk-summary-list">
         <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
@@ -124,7 +132,11 @@ const mainContent = (
 
 `;
 
-export const renderResponseConfigFrom = (authCode: string): string => {
+export const renderResponseConfigFrom = (
+  authCode: string,
+  requestParams: AuthRequestParameters,
+  state: string
+): string => {
   return `<!DOCTYPE html>
   <html lang="en" class="govuk-template">
   
@@ -170,7 +182,7 @@ export const renderResponseConfigFrom = (authCode: string): string => {
     </header>
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper" id="main-content">
-        ${mainContent(authCode)}
+        ${mainContent(authCode, requestParams, state)}
       </main>
     </div>
     <footer class="govuk-footer">

--- a/src/types/auth-request-parameters.ts
+++ b/src/types/auth-request-parameters.ts
@@ -1,3 +1,4 @@
+import ResponseConfiguration from "./response-configuration";
 import { VectorOfTrust } from "./vector-of-trust";
 
 export default interface AuthRequestParameters {
@@ -6,4 +7,5 @@ export default interface AuthRequestParameters {
   scopes: string[];
   claims: string[];
   vtr: VectorOfTrust;
+  responseConfiguration?: ResponseConfiguration;
 }

--- a/tests/integration/form-submit-controller.test.ts
+++ b/tests/integration/form-submit-controller.test.ts
@@ -1,0 +1,125 @@
+import { createApp } from "../../src/app";
+import request from "supertest";
+import { Config } from "../../src/config";
+import { base64url } from "jose";
+import { randomUUID } from "crypto";
+import { VALID_CLAIMS, VALID_SCOPES } from "../../src/constants";
+
+const VERIFIABLE_CREDENTIAL = {
+  type: ["VerifiableCredential"],
+  credentialSubject: {
+    name: [
+      {
+        nameParts: [
+          {
+            value: "John",
+            type: "GivenName",
+          },
+          {
+            value: "Smith",
+            type: "FamilyName",
+            validUntil: "1999-12-31",
+          },
+          {
+            value: "Jones",
+            type: "FamilyName",
+            validFrom: "2000-01-01",
+          },
+        ],
+      },
+    ],
+    birthDate: [
+      {
+        value: "1980-01-01",
+      },
+    ],
+  },
+};
+const RETURN_CODE = [{ code: "example_code" }];
+const SUB_CLAIM =
+  "urn:fdc:gov.uk:2022:56P4CMsGh_02YOlWpd8PAOI-2sVlB2nsNU7mcLZYhYw=";
+const EMAIL = "example@example.com";
+const EMAIL_VERIFIED = "true";
+const PHONE_NUMBER = "07123456789";
+const PHONE_NUMBER_VERIFIED = "true";
+const LOC_ACHIEVED = "P2";
+const PASSPORT_DETAILS = [
+  {
+    expiryDate: "2032-02-02",
+    icaoIssuerCode: "GBR",
+    documentNumber: "1223456",
+  },
+];
+const DRIVING_PERMIT_DETAILS = [
+  {
+    example: "1234567",
+  },
+];
+const POSTAL_ADDRESS_DETAILS = [
+  {
+    example: "1234567",
+  },
+];
+
+describe("FormSubmit controller tests", () => {
+  it("stores the auth request params alongside the response config and redirects", async () => {
+    const app = createApp();
+
+    const redirectUri = "http://example.com/authentication-callback";
+    const authRequestParams = {
+      nonce: randomUUID(),
+      redirectUri,
+      scopes: VALID_SCOPES,
+      claims: VALID_CLAIMS,
+      vtr: {
+        credentialTrust: "Cl.Cm",
+        levelOfConfidence: "P2",
+      },
+    };
+
+    const responseConfig = {
+      sub: SUB_CLAIM,
+      email: EMAIL,
+      emailVerified: EMAIL_VERIFIED,
+      phoneNumber: PHONE_NUMBER,
+      phoneNumberVerified: PHONE_NUMBER_VERIFIED,
+      maxLoCAchieved: LOC_ACHIEVED,
+      coreIdentityVerifiableCredentials: VERIFIABLE_CREDENTIAL,
+      passportDetails: PASSPORT_DETAILS,
+      drivingPermitDetails: DRIVING_PERMIT_DETAILS,
+      postalAddressDetails: POSTAL_ADDRESS_DETAILS,
+      returnCodes: RETURN_CODE,
+    };
+
+    const authCode = randomUUID();
+    const state = randomUUID();
+    const config = Config.getInstance();
+    const encodedAuthRequestParams = base64url.encode(
+      Buffer.from(JSON.stringify(authRequestParams))
+    );
+
+    const response = await request(app)
+      .post("/form-submit")
+      .send({
+        authCode,
+        authRequestParams: encodedAuthRequestParams,
+        state,
+        ...responseConfig,
+      });
+
+    expect(response.status).toEqual(302);
+    expect(response.header.location).toEqual(
+      `${redirectUri}?code=${authCode}&state=${state}`
+    );
+
+    const storedConfig = config.getAuthCodeRequestParams(authCode);
+    expect(storedConfig).toStrictEqual({
+      ...authRequestParams,
+      responseConfiguration: {
+        ...responseConfig,
+        emailVerified: responseConfig.emailVerified === "true",
+        phoneNumberVerified: responseConfig.phoneNumberVerified === "true",
+      },
+    });
+  });
+});


### PR DESCRIPTION
### What: 
- Adds a new controller to handle the response config form submission 
- Modifies the form to include base64URL encoded auth request params to persist them between `/authorize` and form submission 
- Stores the submitted response configuration alongside the auth code when the form is submitted

### Why:
- This allows us to store the form submitted response configuration alongside the auth request params, which allows us to persist this information when we're issuing access tokens and eventually the `/userinfo` response

### Manual testing: 
-  Run the simulator in interactive mode and make an `/authorize` request. Upon clicking submit you should be redirected to the redirect_uri with an auth code
- To run this run: 
```
npm run build && INTERACTIVE_MODE=true npm run start
```

> [!NOTE]  
> Sonar thinks this introduces a vulnerability but we validate the redirect uri, so this is not a concern 
