### PR TITLE
ATO-1379: support pkce in /authorize endpoint

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -28,6 +28,7 @@ export class Config {
 
   private simulatorUrl: string;
   private readonly interactiveMode: boolean;
+  private readonly pkceEnabled: boolean;
 
   private constructor() {
     const defaultPublicKey = `-----BEGIN PUBLIC KEY-----
@@ -137,6 +138,7 @@ CQIDAQAB
 
     this.simulatorUrl = process.env.SIMULATOR_URL ?? "http://localhost:3000";
     this.interactiveMode = process.env.INTERACTIVE_MODE === "true";
+    this.pkceEnabled = process.env.PKCE_ENABLED === "true";
   }
 
   public static getInstance(): Config {
@@ -421,7 +423,12 @@ CQIDAQAB
   public getDidController(): string {
     return `did:web:${new URL(this.simulatorUrl).host.replace(":", encodeURIComponent(":"))}`;
   }
+
   public isInteractiveModeEnabled(): boolean {
     return this.interactiveMode;
+  }
+
+  public isPKCEEnabled(): boolean {
+    return this.pkceEnabled;
   }
 }

--- a/src/parse/parse-auth-request.ts
+++ b/src/parse/parse-auth-request.ts
@@ -33,6 +33,8 @@ export type AuthRequest = {
   max_age: number;
   request_uri?: string;
   requestObject?: RequestObject;
+  code_challenge?: string;
+  code_challenge_method?: string;
 };
 
 export const parseAuthRequest = (
@@ -145,6 +147,8 @@ export const parseAuthRequest = (
     max_age,
     request_uri: authRequest.request_uri,
     requestObject,
+    code_challenge: authRequest.code_challenge,
+    code_challenge_method: authRequest.code_challenge_method,
   };
 };
 

--- a/src/parse/tests/parse-auth-request.test.ts
+++ b/src/parse/tests/parse-auth-request.test.ts
@@ -207,6 +207,8 @@ describe("parseAuthRequest tests", () => {
           vtr: '["Cl.Cm"]',
           nonce: "8b5376320b7d9307627a5ad9512da4f84555d96fe9517365",
           prompt: "none",
+          code_challenge: "code-challenge",
+          code_challenge_method: "code-challenge-method",
         })
       ).toStrictEqual({
         response_type: "code",
@@ -226,6 +228,8 @@ describe("parseAuthRequest tests", () => {
         requestObject: undefined,
         request_uri: undefined,
         max_age: -1,
+        code_challenge: "code-challenge",
+        code_challenge_method: "code-challenge-method",
       });
     });
   });
@@ -237,6 +241,8 @@ describe("parseAuthRequest tests", () => {
         client_id: clientId,
         scope: "openid",
         request: defaultEncodedJwt,
+        code_challenge: "code-challenge",
+        code_challenge_method: "code-challenge-method",
       });
 
       expect(parsedRequest).toStrictEqual({
@@ -268,6 +274,8 @@ describe("parseAuthRequest tests", () => {
         ui_locales: [],
         request_uri: undefined,
         max_age: -1,
+        code_challenge: "code-challenge",
+        code_challenge_method: "code-challenge-method",
       });
     });
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -69,6 +69,8 @@ export const transformRequestObject = (
   const claims = payload.claims ? getClaimsKeys(payload.claims as string) : [];
   const vtr = payload.vtr as VectorOfTrust[];
   const ui_locales = payload.ui_locales;
+  const code_challenge = payload.code_challenge;
+  const code_challenge_method = payload.code_challenge_method;
   let prompt = [];
   try {
     prompt = parsePrompts(
@@ -94,6 +96,8 @@ export const transformRequestObject = (
     prompt,
     ui_locales,
     max_age,
+    code_challenge,
+    code_challenge_method,
   } as AuthRequest;
 };
 

--- a/src/validators/code-challenge-validator.ts
+++ b/src/validators/code-challenge-validator.ts
@@ -1,0 +1,45 @@
+import { AuthoriseRequestError } from "../errors/authorise-request-error";
+
+const validCodeChallengeMethod = "S256";
+
+export const validatePKCECodeChallengeAndMethod = (
+  redirectUri: string,
+  state: string,
+  codeChallenge?: string,
+  codeChallengeMethod?: string
+): void => {
+  if (codeChallenge === null) {
+    return;
+  }
+
+  if (!codeChallenge || codeChallenge.trim() === "") {
+    throw new AuthoriseRequestError({
+      errorCode: "invalid_request",
+      errorDescription: "Invalid value for code_challenge parameter.",
+      httpStatusCode: 302,
+      redirectUri,
+      state,
+    });
+  }
+
+  if (codeChallengeMethod === null || !codeChallengeMethod) {
+    throw new AuthoriseRequestError({
+      errorCode: "invalid_request",
+      errorDescription:
+        "Request is missing code_challenge_method parameter. code_challenge_method is required when code_challenge is present.",
+      httpStatusCode: 302,
+      redirectUri,
+      state,
+    });
+  }
+
+  if (codeChallengeMethod !== validCodeChallengeMethod) {
+    throw new AuthoriseRequestError({
+      errorCode: "invalid_request",
+      errorDescription: "Invalid value for code_challenge_method parameter.",
+      httpStatusCode: 302,
+      redirectUri,
+      state,
+    });
+  }
+};

--- a/src/validators/tests/validate-auth-request-query-params.test.ts
+++ b/src/validators/tests/validate-auth-request-query-params.test.ts
@@ -193,4 +193,78 @@ describe("validateAuthRequestQueryParams tests", () => {
       })
     );
   });
+
+  describe('when PKCE_ENABLED is set to "true"', () => {
+    beforeAll(() => {
+      jest.spyOn(config, "isPKCEEnabled").mockReturnValue(true);
+    });
+
+    afterAll(() => {
+      jest.spyOn(config, "isPKCEEnabled").mockReturnValue(false);
+    });
+
+    it("throw authorise request error when code challenge method is not S256", () => {
+      expect(() =>
+        validateAuthRequestQueryParams(
+          {
+            ...defaultAuthRequest,
+            code_challenge_method: "not-S256",
+            code_challenge: "code-challenge",
+          },
+          config
+        )
+      ).toThrow(
+        new AuthoriseRequestError({
+          errorCode: "invalid_request",
+          errorDescription:
+            "Invalid value for code_challenge_method parameter.",
+          httpStatusCode: 302,
+          redirectUri: defaultAuthRequest.redirect_uri,
+          state: defaultAuthRequest.state,
+        })
+      );
+    });
+
+    it("throw authorise request error when code challenge method is null", async () => {
+      expect(() =>
+        validateAuthRequestQueryParams(
+          {
+            ...defaultAuthRequest,
+            code_challenge: "code-challenge",
+          },
+          config
+        )
+      ).toThrow(
+        new AuthoriseRequestError({
+          errorCode: "invalid_request",
+          errorDescription:
+            "Request is missing code_challenge_method parameter. code_challenge_method is required when code_challenge is present.",
+          httpStatusCode: 302,
+          redirectUri: defaultAuthRequest.redirect_uri,
+          state: defaultAuthRequest.state,
+        })
+      );
+    });
+
+    it("throw authorise request error when code challenge is whitespace", () => {
+      expect(() =>
+        validateAuthRequestQueryParams(
+          {
+            ...defaultAuthRequest,
+            code_challenge_method: "S256",
+            code_challenge: " ",
+          },
+          config
+        )
+      ).toThrow(
+        new AuthoriseRequestError({
+          errorCode: "invalid_request",
+          errorDescription: "Invalid value for code_challenge parameter.",
+          httpStatusCode: 302,
+          redirectUri: defaultAuthRequest.redirect_uri,
+          state: defaultAuthRequest.state,
+        })
+      );
+    });
+  });
 });

--- a/src/validators/validate-auth-request-object.ts
+++ b/src/validators/validate-auth-request-object.ts
@@ -14,6 +14,7 @@ import {
 import { areScopesValid } from "./scope-validator";
 import { vtrValidator } from "./vtr-validator";
 import { areClaimsValid } from "./claims-validator";
+import { validatePKCECodeChallengeAndMethod } from "./code-challenge-validator";
 
 export const validateAuthRequestObject = async (
   authRequest: AuthRequest,
@@ -165,6 +166,15 @@ export const validateAuthRequestObject = async (
   }
 
   validateMaxAge(payload);
+
+  if (config.isPKCEEnabled()) {
+    validatePKCECodeChallengeAndMethod(
+      payload.redirect_uri as string,
+      payload.state as string,
+      payload.code_challenge as string,
+      payload.code_challenge_method as string
+    );
+  }
 
   logger.info("RequestObject has passed initial validation");
 };

--- a/src/validators/validate-auth-request-query-params.ts
+++ b/src/validators/validate-auth-request-query-params.ts
@@ -6,6 +6,7 @@ import { areScopesValid } from "./scope-validator";
 import { vtrValidator } from "./vtr-validator";
 import { Config } from "../config";
 import { AuthRequest } from "src/parse/parse-auth-request";
+import { validatePKCECodeChallengeAndMethod } from "./code-challenge-validator";
 
 export const validateAuthRequestQueryParams = (
   queryParams: AuthRequest,
@@ -101,5 +102,14 @@ export const validateAuthRequestQueryParams = (
       redirectUri: queryParams.redirect_uri,
       state: queryParams.state,
     });
+  }
+
+  if (config.isPKCEEnabled()) {
+    validatePKCECodeChallengeAndMethod(
+      queryParams.redirect_uri,
+      queryParams.state,
+      queryParams.code_challenge,
+      queryParams.code_challenge_method
+    );
   }
 };


### PR DESCRIPTION
## Wider context of change:

As part of supporting PKCE, we need to update the simulator to support PKCE behind a env variable.

# What's changed:

Added PKCE support to the `/authorize` endpoint.