### PR TITLE
ATO-1020: validate response mode if present

### DIFF
--- a/src/parse/parse-auth-request.ts
+++ b/src/parse/parse-auth-request.ts
@@ -35,6 +35,7 @@ export type AuthRequest = {
   requestObject?: RequestObject;
   code_challenge?: string;
   code_challenge_method?: string;
+  response_mode?: string;
 };
 
 export const parseAuthRequest = (
@@ -149,6 +150,7 @@ export const parseAuthRequest = (
     requestObject,
     code_challenge: authRequest.code_challenge,
     code_challenge_method: authRequest.code_challenge_method,
+    response_mode: authRequest.response_mode,
   };
 };
 

--- a/src/parse/tests/parse-auth-request.test.ts
+++ b/src/parse/tests/parse-auth-request.test.ts
@@ -209,6 +209,7 @@ describe("parseAuthRequest tests", () => {
           prompt: "none",
           code_challenge: "code-challenge",
           code_challenge_method: "code-challenge-method",
+          response_mode: "query",
         })
       ).toStrictEqual({
         response_type: "code",
@@ -230,6 +231,7 @@ describe("parseAuthRequest tests", () => {
         max_age: -1,
         code_challenge: "code-challenge",
         code_challenge_method: "code-challenge-method",
+        response_mode: "query",
       });
     });
   });
@@ -273,6 +275,7 @@ describe("parseAuthRequest tests", () => {
         prompt: [],
         ui_locales: [],
         request_uri: undefined,
+        response_mode: undefined,
         max_age: -1,
         code_challenge: "code-challenge",
         code_challenge_method: "code-challenge-method",

--- a/src/validators/tests/validate-auth-request-object.test.ts
+++ b/src/validators/tests/validate-auth-request-object.test.ts
@@ -436,6 +436,20 @@ describe("Validate auth request object tests", () => {
     );
   });
 
+  it("throw bad request error response_mode for unknown response_mode", async () => {
+    const requestObject = requestObjectWithParams({
+      response_mode: "code",
+    });
+    const authRequest = {
+      ...defaultAuthRequest,
+      requestObject,
+    };
+
+    await expect(
+      validateAuthRequestObject(authRequest, config)
+    ).rejects.toThrow(new BadRequestError("Invalid request"));
+  });
+
   describe('when PKCE_ENABLED is set to "true"', () => {
     beforeAll(() => {
       jest.spyOn(config, "isPKCEEnabled").mockReturnValue(true);

--- a/src/validators/tests/validate-auth-request-query-params.test.ts
+++ b/src/validators/tests/validate-auth-request-query-params.test.ts
@@ -194,6 +194,18 @@ describe("validateAuthRequestQueryParams tests", () => {
     );
   });
 
+  it("throw authorise request error when response mode is not query or fragment", () => {
+    expect(() =>
+      validateAuthRequestQueryParams(
+        {
+          ...defaultAuthRequest,
+          response_mode: "code",
+        },
+        config
+      )
+    ).toThrow(new BadRequestError("Invalid request"));
+  });
+
   describe('when PKCE_ENABLED is set to "true"', () => {
     beforeAll(() => {
       jest.spyOn(config, "isPKCEEnabled").mockReturnValue(true);

--- a/src/validators/validate-auth-request-object.ts
+++ b/src/validators/validate-auth-request-object.ts
@@ -176,6 +176,15 @@ export const validateAuthRequestObject = async (
     );
   }
 
+  if (
+    payload.response_mode &&
+    payload.response_mode !== "query" &&
+    payload.response_mode !== "fragment"
+  ) {
+    logger.error(`Invalid response mode in request: ${payload.response_mode}`);
+    throw new BadRequestError("Invalid request");
+  }
+
   logger.info("RequestObject has passed initial validation");
 };
 

--- a/src/validators/validate-auth-request-query-params.ts
+++ b/src/validators/validate-auth-request-query-params.ts
@@ -112,4 +112,15 @@ export const validateAuthRequestQueryParams = (
       queryParams.code_challenge_method
     );
   }
+
+  if (
+    queryParams.response_mode &&
+    queryParams.response_mode !== "query" &&
+    queryParams.response_mode !== "fragment"
+  ) {
+    logger.error(
+      `Invalid response mode in request: ${queryParams.response_mode}`
+    );
+    throw new BadRequestError("Invalid request");
+  }
 };

--- a/tests/integration/authorise-get-controller.test.ts
+++ b/tests/integration/authorise-get-controller.test.ts
@@ -167,6 +167,26 @@ describe("Authorise controller tests", () => {
         expect(response.status).toBe(400);
         expect(response.text).toBe("Invalid Request");
       });
+
+      it("returns an invalid request for unknown response_mode", async () => {
+        const app = createApp();
+        const requestParams = createRequestParams({
+          client_id: knownClientId,
+          redirect_uri: knownRedirectUri,
+          response_type: "code",
+          response_mode: "form_post",
+          scope: "openid email",
+          state,
+          nonce,
+        });
+
+        const response = await request(app).get(
+          authoriseEndpoint + "?" + requestParams
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.text).toBe("Invalid Request");
+      });
     });
 
     describe("/authorize GET controller: Invalid request, redirecting errors", () => {
@@ -448,7 +468,7 @@ describe("Authorise controller tests", () => {
         }
       );
 
-      it("returns 302 and redirects with an error code and description", async () => {
+      it("returns 302 and redirects with an unmet_authentication_requirements error when the prompt includes select_account", async () => {
         const app = createApp();
         const requestParams = createRequestParams({
           client_id: knownClientId,
@@ -639,6 +659,26 @@ describe("Authorise controller tests", () => {
           scope: "openid email",
           request: await encodedJwtWithParams({
             redirect_uri: "https://example.com/auth-callback",
+          }),
+        });
+
+        const response = await request(app).get(
+          authoriseEndpoint + "?" + requestParams
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.text).toBe("Invalid Request");
+      });
+
+      it("returns a 400 and Invalid request for an unknown response_mode", async () => {
+        const app = createApp();
+        const requestParams = createRequestParams({
+          client_id: knownClientId,
+          redirect_uri: knownRedirectUri,
+          response_type: "code",
+          scope: "openid email",
+          request: await encodedJwtWithParams({
+            response_mode: "form_post",
           }),
         });
 


### PR DESCRIPTION
We are updating the main API to validate the response_mode field. We should add this to the simulator to match.

https://github.com/govuk-one-login/authentication-api/pull/6099