### PR TITLE
BAU: Fix expires_in field

### DIFF
--- a/src/components/token/token-controller.ts
+++ b/src/components/token/token-controller.ts
@@ -8,6 +8,7 @@ import { ParseTokenRequestError } from "../../errors/parse-token-request-error";
 import { parseTokenRequest } from "../../parse/parse-token-request";
 import ResponseConfiguration from "src/types/response-configuration";
 import { comparePKCECodeChallengeAndVerifier } from "./helper/code-challenge-comparer";
+import { ACCESS_TOKEN_EXPIRY } from "../../constants";
 
 export const tokenController = async (
   req: Request,
@@ -80,7 +81,7 @@ export const tokenController = async (
     res.status(200).json({
       access_token: accessToken,
       token_type: "Bearer",
-      expires_in: 3600,
+      expires_in: ACCESS_TOKEN_EXPIRY,
       id_token: idToken,
     });
 

--- a/tests/integration/token-controller.test.ts
+++ b/tests/integration/token-controller.test.ts
@@ -700,7 +700,7 @@ describe("/token endpoint valid client_assertion", () => {
     const decodedAccessToken = decodeJwtNoVerify(access_token);
     const decodedIdToken = decodeJwtNoVerify(id_token);
 
-    expect(expires_in).toEqual(3600);
+    expect(expires_in).toEqual(180);
     expect(token_type).toEqual("Bearer");
 
     expect(decodedAccessToken.protectedHeader).toStrictEqual({
@@ -782,7 +782,7 @@ describe('when INTERACTIVE_MODE is set to "true"', () => {
     const decodedAccessToken = decodeJwtNoVerify(access_token);
     const decodedIdToken = decodeJwtNoVerify(id_token);
 
-    expect(expires_in).toEqual(3600);
+    expect(expires_in).toEqual(180);
     expect(token_type).toEqual("Bearer");
 
     expect(decodedAccessToken.protectedHeader).toStrictEqual({


### PR DESCRIPTION
The expires_in field represents the access token expiry in seconds[1]. Our access token is not valid for 3600 seconds, so this value was wrong

[1]- https://datatracker.ietf.org/doc/html/rfc6749#section-4.2.2