### PR TITLE
Split user and maintainer documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,11 @@
 # Developing for the GOV.UK One Login Simulator
+These instructions are primarily intended for developers working on GOV.UK One Login.
+
+We would be happy to accept contributions from elsewhere, but cannot guarantee that we will be able to accept every change.
+For example, we will be unable to accept new features that the team would be unable to support on an ongoing basis.
+
+You can use a GitHub issue to get feedback on new features before you begin.
+
 ## Local Setup
 
 To run the stub locally, you can simply run `docker compose up --build`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Developing for the GOV.UK One Login Simulator
+## Local Setup
+
+To run the stub locally, you can simply run `docker compose up --build`.
+
+If you would like to run it alongside an RP running locally in Docker, you'll need to turn on Docker host networking.
+This requires v4.34 or higher of Docker Desktop. In Docker Desktop, go into Settings -> Resources -> Network, and tick
+`Enable host networking`. In your docker compose file for the RP, add `network_mode: host` under the service that you're running.
+<br />
+
+### Development environment setup:
+
+_Please ensure you are using the correct node version locally (Found in Dockerfile)_
+
+#### Build
+
+> To build the app
+
+```shell script
+npm install && npm run build
+```
+
+#### Start
+
+> To start the app
+
+```shell script
+npm run build && npm run start
+```
+
+<br />
+
+## Formatting & Linting
+
+### Scripts:
+
+> To check:
+
+```shell script
+npm run check; # Check all
+npm run check:pretty; # Check prettier
+npm run check:lint; # Check linting
+```
+
+> To fix formatting/linting:
+
+```shell script
+npm run fix; # Fix all
+npm run fix:pretty; # Fix prettier
+npm run fix:lint; # Fix linting
+```
+
+> To setup pre-commit hook
+
+```shell script
+npm run prepare
+```
+
+## Testing
+
+> To run tests run
+
+```shell script
+npm run test
+```

--- a/README.md
+++ b/README.md
@@ -1,70 +1,5 @@
 # GOV.UK One Login Simulator
 
-## Local Setup
-
-To run the stub locally, you can simply run `docker compose up --build`.
-
-If you would like to run it alongside an RP running locally in Docker, you'll need to turn on Docker host networking.
-This requires v4.34 or higher of Docker Desktop. In Docker Desktop, go into Settings -> Resources -> Network, and tick
-`Enable host networking`. In your docker compose file for the RP, add `network_mode: host` under the service that you're running.
-<br />
-
-### Development environment setup:
-
-_Please ensure you are using the correct node version locally (Found in Dockerfile)_
-
-#### Build
-
-> To build the app
-
-```shell script
-npm install && npm run build
-```
-
-#### Start
-
-> To start the app
-
-```shell script
-npm run build && npm run start
-```
-
-<br />
-
-## Formatting & Linting
-
-### Scripts:
-
-> To check:
-
-```shell script
-npm run check; # Check all
-npm run check:pretty; # Check prettier
-npm run check:lint; # Check linting
-```
-
-> To fix formatting/linting:
-
-```shell script
-npm run fix; # Fix all
-npm run fix:pretty; # Fix prettier
-npm run fix:lint; # Fix linting
-```
-
-> To setup pre-commit hook
-
-```shell script
-npm run prepare
-```
-
-## Testing
-
-> To run tests run
-
-```shell script
-npm run test
-```
-
 ## Using the simulator:
 
 The GOV.UK One Login simulator is a development tool that lets you run end-to-end tests, so you can:
@@ -102,3 +37,6 @@ The simulator aims to mirror GOV.UK One Login but does not support all of the fe
 - [Configuring Errors](./docs/configured-errors.md)
 - [Default configuration values](./docs/default-config-values.md)
 - [Running the simulator in interactive mode](./docs/interactive-mode.md)
+
+## Developing on the Simulator
+Developer instructions can be found in [CONTRIBUTING.md](./CONTRIBUTING.md)


### PR DESCRIPTION
It's not clear what in the README is intended for who. I've kept the readme as RP facing docs, and moved out the internal stuff. I've also added a couple of lines about external contributions