### PR TITLE
Use the correct subject claim value in the tokens when using interactive mode

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npm run check:lint
 npm run check:pretty

--- a/src/components/token/helper/create-access-token.ts
+++ b/src/components/token/helper/create-access-token.ts
@@ -13,14 +13,16 @@ import { VectorOfTrust } from "../../../types/vector-of-trust";
 export const createAccessToken = async (
   scope: string[],
   vtr: VectorOfTrust,
-  claims?: string[] | null
+  claims?: string[] | null,
+  userDefinedSub?: string | null
 ): Promise<string> => {
   logger.info("Creating access token");
   const config = Config.getInstance();
   const accessTokenClaims = createAccessTokenClaimSet(
     scope,
     config,
-    getClaimsRequest(vtr, claims)
+    getClaimsRequest(vtr, claims),
+    userDefinedSub
   );
   const accessToken = await signToken(accessTokenClaims);
   return accessToken;
@@ -39,13 +41,14 @@ export const getClaimsRequest = (
 const createAccessTokenClaimSet = (
   scope: string[],
   config: Config,
-  claims?: string[] | null
+  claims?: string[] | null,
+  userDefinedSub?: string | null
 ): AccessTokenClaims => {
   const iat = Math.floor(Date.now() / 1000);
   const exp = iat + ACCESS_TOKEN_EXPIRY;
   const jti = randomUUID();
   const sid = SESSION_ID;
-  const sub = config.getSub();
+  const sub = userDefinedSub ? userDefinedSub : config.getSub();
   const clientId = config.getClientId();
 
   return {

--- a/src/components/token/helper/create-id-token.ts
+++ b/src/components/token/helper/create-id-token.ts
@@ -64,7 +64,9 @@ const createIdTokenClaimSet = (
     iat,
     exp,
     at_hash: generateAccessTokenHash(accessToken),
-    sub: config.getSub(),
+    sub: authRequestParams.responseConfiguration?.sub
+      ? authRequestParams.responseConfiguration.sub
+      : config.getSub(),
     aud: idTokenErrors.includes("INVALID_AUD")
       ? randomBytes(32).toString()
       : config.getClientId(),

--- a/src/components/token/tests/helper/create-access-token.test.ts
+++ b/src/components/token/tests/helper/create-access-token.test.ts
@@ -116,4 +116,26 @@ describe("createAccessToken tests", () => {
 
     expect(payload).not.toHaveProperty("claims");
   });
+
+  it("returns a token with the user defined sub when using interactive mode", async () => {
+    const vtr: VectorOfTrust = {
+      credentialTrust: "Cl.Cm",
+      levelOfConfidence: "P2",
+    };
+    subSpy.mockReturnValue(testSubClaim);
+    clientIdSpy.mockReturnValue(testClientId);
+
+    const testUserDefinedSub = "Sj80MyJ0LFQxISo7LDp7L2ZAVUo-JTI_fVEhTFtJRg==";
+    const accessToken = await createAccessToken(
+      ["openid"],
+      vtr,
+      VALID_CLAIMS,
+      testUserDefinedSub
+    );
+    const tokenParts = accessToken.split(".");
+
+    const payload = decodeTokenPart(tokenParts[1]);
+
+    expect(payload.sub).toBe(testUserDefinedSub);
+  });
 });

--- a/src/components/token/tests/helper/create-id-token.test.ts
+++ b/src/components/token/tests/helper/create-id-token.test.ts
@@ -223,4 +223,20 @@ describe("createIdToken tests", () => {
     const payload = decodeTokenPart(idToken.split(".")[1]);
     expect(payload.iss).not.toEqual(mockAuthRequestParams.nonce);
   });
+
+  it("returns a token with the user defined sub when using interactive mode", async () => {
+    tokenSigningAlgorithmSpy.mockReturnValue("ES256");
+    subSpy.mockReturnValue(testSubClaim);
+    clientIdSpy.mockReturnValue(testClientId);
+
+    const testUserDefinedSub = "Sj80MyJ0LFQxISo7LDp7L2ZAVUo-JTI_fVEhTFtJRg==";
+    mockAuthRequestParams.responseConfiguration = {
+      sub: testUserDefinedSub,
+    };
+
+    const idToken = await createIdToken(mockAuthRequestParams, testAccessToken);
+
+    const payload = decodeTokenPart(idToken.split(".")[1]);
+    expect(payload.sub).toBe(testUserDefinedSub);
+  });
 });

--- a/src/components/token/token-controller.ts
+++ b/src/components/token/token-controller.ts
@@ -55,7 +55,8 @@ export const tokenController = async (
     const accessToken = await createAccessToken(
       authCodeParams.scopes,
       authCodeParams.vtr,
-      authCodeParams.claims
+      authCodeParams.claims,
+      authCodeParams.responseConfiguration?.sub
     );
     const idToken = await createIdToken(authCodeParams, accessToken);
 

--- a/tests/integration/token-controller.test.ts
+++ b/tests/integration/token-controller.test.ts
@@ -789,7 +789,7 @@ describe('when INTERACTIVE_MODE is set to "true"', () => {
       alg: "RS256",
       kid: RSA_PRIVATE_TOKEN_SIGNING_KEY_ID,
     });
-    expect(decodedAccessToken.payload.sub).toBe(knownSub);
+    expect(decodedAccessToken.payload.sub).toBe(responseConfiguration.sub);
     expect(decodedAccessToken.payload.client_id).toBe(knownClientId);
     expect(decodedAccessToken.payload.sid).toBe(SESSION_ID);
     expect(decodedAccessToken.payload.scope).toStrictEqual(
@@ -800,7 +800,7 @@ describe('when INTERACTIVE_MODE is set to "true"', () => {
       alg: "RS256",
       kid: RSA_PRIVATE_TOKEN_SIGNING_KEY_ID,
     });
-    expect(decodedIdToken.payload.sub).toBe(knownSub);
+    expect(decodedIdToken.payload.sub).toBe(responseConfiguration.sub);
     expect(decodedIdToken.payload.iss).toBe("http://localhost:3000/");
     expect(decodedIdToken.payload.vtm).toBe("http://localhost:3000/trustmark");
     expect(decodedIdToken.payload.aud).toBe(knownClientId);


### PR DESCRIPTION
This is to fix an issue where when using interactive mode, both the `id_token` and the `access_token` contain the preconfigured value under the `sub` claim instead of the one specified by the user in the form. The `userinfo` endpoint doesn't seem to suffer from the same issue and is returning the expected `sub` value.

The unit tests have been updated to accommodate the changes, and also to fix the health check test which was failing.

The `.husky/pre-commit` has also been updated to according to the "How to Migrate" section of the [husky v9.0.1 release notes](https://github.com/typicode/husky/releases/tag/v9.0.1).