### PR TITLE
BAU: Don't validate the exp claim in id_token_hint

### DIFF
--- a/src/components/logout/logout-controller.ts
+++ b/src/components/logout/logout-controller.ts
@@ -142,7 +142,9 @@ const isIdTokenSignatureValid = async (idToken: string): Promise<boolean> => {
         EC_PRIVATE_TOKEN_SIGNING_KEY,
         EC_PRIVATE_TOKEN_SIGNING_KEY_ID
       );
-      await jwtVerify(idToken, ecKey);
+      await jwtVerify(idToken, ecKey, { currentDate: new Date(0) });
+      //We shouldn't validate the exp claim here, hence the Date(0)
+      // https://openid.net/specs/openid-connect-rpinitiated-1_0.html#:~:text=When%20an%20id_token_hint,act%20upon%20it.
       return true;
     }
   } catch (error) {


### PR DESCRIPTION
The actual logout endpoint does not do this validation and this is correct according to the spec[1]. JOSE does this by default but we can stop this by over-riding the current date to 0, therefore making all id_token_hints pass the exp validation.

[1]- https://openid.net/specs/openid-connect-rpinitiated-1_0.html#:~:text=When%20an%20id_token_hint,act%20upon%20it.