### PR TITLE
BAU: Use user defined subject claim when issuing tokens

### DIFF
--- a/src/components/token/helper/create-id-token.ts
+++ b/src/components/token/helper/create-id-token.ts
@@ -64,7 +64,7 @@ const createIdTokenClaimSet = (
     iat,
     exp,
     at_hash: generateAccessTokenHash(accessToken),
-    sub: config.getSub(),
+    sub: authRequestParams.responseConfiguration?.sub ?? config.getSub(),
     aud: idTokenErrors.includes("INVALID_AUD")
       ? randomBytes(32).toString()
       : config.getClientId(),

--- a/src/components/token/token-controller.ts
+++ b/src/components/token/token-controller.ts
@@ -52,11 +52,8 @@ export const tokenController = async (
       });
     }
 
-    const accessToken = await createAccessToken(
-      authCodeParams.scopes,
-      authCodeParams.vtr,
-      authCodeParams.claims
-    );
+    const accessToken = await createAccessToken(authCodeParams);
+
     const idToken = await createIdToken(authCodeParams, accessToken);
 
     if (config.isInteractiveModeEnabled()) {

--- a/tests/integration/token-controller.test.ts
+++ b/tests/integration/token-controller.test.ts
@@ -789,7 +789,7 @@ describe('when INTERACTIVE_MODE is set to "true"', () => {
       alg: "RS256",
       kid: RSA_PRIVATE_TOKEN_SIGNING_KEY_ID,
     });
-    expect(decodedAccessToken.payload.sub).toBe(knownSub);
+    expect(decodedAccessToken.payload.sub).toBe(responseConfiguration.sub);
     expect(decodedAccessToken.payload.client_id).toBe(knownClientId);
     expect(decodedAccessToken.payload.sid).toBe(SESSION_ID);
     expect(decodedAccessToken.payload.scope).toStrictEqual(
@@ -800,7 +800,7 @@ describe('when INTERACTIVE_MODE is set to "true"', () => {
       alg: "RS256",
       kid: RSA_PRIVATE_TOKEN_SIGNING_KEY_ID,
     });
-    expect(decodedIdToken.payload.sub).toBe(knownSub);
+    expect(decodedIdToken.payload.sub).toBe(responseConfiguration.sub);
     expect(decodedIdToken.payload.iss).toBe("http://localhost:3000/");
     expect(decodedIdToken.payload.vtm).toBe("http://localhost:3000/trustmark");
     expect(decodedIdToken.payload.aud).toBe(knownClientId);


### PR DESCRIPTION
We previously added interactive mode, which allowed RPs to define the response data for the userinfo endpoint. We did not update the tokens issued at the token endpoint to reflect this. This fixes this issue.