### PR TITLE
ATO-1619 Enable manual trigger for acceptance tests

### DIFF
--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -3,6 +3,7 @@ name: Run Acceptance Tests
 on:
   schedule:
     - cron: "0 3 * * *"
+  workflow_dispatch:
 
 jobs:
   run-acceptance-tests:


### PR DESCRIPTION
Context: A [dependabot update to the node version](https://github.com/govuk-one-login/simulator/pull/287) was merged. We want to ensure that the docker image will continue build and run correctly, without waiting for overnight acceptance tests.
- Allow acceptance tests to be triggered manually