### PR TITLE
BAU: Add script to run acceptance tests locally

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,11 @@
+TEST_USER_PHONE_NUMBER_VERIFIED=true
+TEST_USER_EMAIL_VERIFIED=true
+
+# Change the variables below to an account you have setup in build
+# Details about the type of account to create, and getting the phone verify code can be found in confluence
+# You can find your sub value after you login, at the user info screen
+TEST_USER_EMAIL=changeme
+TEST_USER_PASSWORD=changeme
+TEST_USER_PHONE_NUMBER=changeme
+TEST_USER_SUB=changeme
+TEST_USER_PHONE_VERIFY_CODE=changeme

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,5 @@ dist
 .idea
 
 reports/*
+
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ dist
 reports/*
 
 .DS_Store
+.env

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,11 +62,25 @@ npm run fix:lint; # Fix linting
 ```shell script
 npm run prepare
 ```
+## Tests
+### Unit tests/Integration tests
 
-## Testing
-
-> To run tests run
+> To run all unit tests and integration tests, run
 
 ```shell script
 npm run test
 ```
+
+### Acceptance tests
+
+To run the acceptance tests locally:
+1. Create an account in the build environment that is a test client (email starts with `orch-test-user`).
+2. Make a copy of the `.env.template` file and rename it to `.env`.
+3. Update the test variables in `.env` to point to the account you have setup in step 1.
+4. Run the acceptance tests with the following command:
+```shell script
+./run-acceptance-tests.sh
+```
+
+These tests will generate a report with screenshots that you can view at `reports/cucumber-report.html`
+

--- a/acceptance-tests.docker-compose.yaml
+++ b/acceptance-tests.docker-compose.yaml
@@ -1,0 +1,20 @@
+services:
+  simulator:
+    container_name: simulator
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      REDIRECT_URLS: "http://localhost:3001/callback"
+      CLAIMS: "https://vocab.account.gov.uk/v1/coreIdentityJWT,https://vocab.account.gov.uk/v1/address,https://vocab.account.gov.uk/v1/passport"
+    restart: on-failure
+    network_mode: host
+  selenium:
+    image: ${SELENIUM_IMAGE}
+    network_mode: host
+  micro-rp:
+    build:
+      context: ./tests/acceptance/micro-rp
+      dockerfile: Dockerfile
+    restart: on-failure
+    network_mode: host

--- a/run-acceptance-tests.sh
+++ b/run-acceptance-tests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# shellcheck source=/dev/null
+set -o allexport && source .env && set +o allexport
+
+ARCH=$(uname -m)
+if [ "$ARCH" = "arm64" ]; then
+  export SELENIUM_IMAGE="seleniarm/standalone-chromium:latest"
+else
+  export SELENIUM_IMAGE="selenium/standalone-chromium:latest"
+fi
+
+docker compose --file acceptance-tests.docker-compose.yaml up -d
+echo "Waiting for a second for ports to open"
+sleep 1
+npm run acceptance-test


### PR DESCRIPTION
## What
Adds a script to run all acceptance tests locally. The script will start containers for the simulator, selenium, and the micro RP images. 

The script uses environment variables defined in a file called `.env`. There is a template file (`.env.template`) that can be used to create this file. The variables must belong to an account that already exists in the build environment.

Also updates the docs to explain how to run the script. 