### PR TITLE
BAU - Bump node to 22.15.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:22.15.0@sha256:473b4362b26d05e157f8470a1f0686cab6a62d1bd2e59774079ddf6fecd8e37e as base
+FROM node:22.15.1@sha256:e558507eb799e3a76fcdaaee5e48dce1a00aebc85892128a9fca59f63bd49511 as base
 WORKDIR /app
 COPY . ./
 RUN npm install 
 RUN npm run build
 
-FROM node:22.15.0@sha256:473b4362b26d05e157f8470a1f0686cab6a62d1bd2e59774079ddf6fecd8e37e as release
+FROM node:22.15.1@sha256:e558507eb799e3a76fcdaaee5e48dce1a00aebc85892128a9fca59f63bd49511 as release
 WORKDIR /app
 COPY --chown=node:node --from=base /app/package*.json ./
 COPY --chown=node:node --from=base /app/node_modules/ node_modules


### PR DESCRIPTION
Bump node to patch vulnerabilities as per [changelog](https://github.com/nodejs/node/releases/tag/v22.15.1).

Tested by running docker locally and logging the version:

```
simulator  | 
simulator  | > simulator@1.0.0 start
simulator  | > node dist/server.js
simulator  | 
simulator  | Running Node.js version: v22.15.1
simulator  | {"level":30,"time":1747390789977,"pid":19,"hostname":"docker-desktop","msg":"[server]: Server is running at http://localhost:3000"}
```

