### PR TITLE
ATO-1566: Allow issuer as private_key_jwt_aud

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -412,8 +412,8 @@ CQIDAQAB
     return `${this.simulatorUrl}/`;
   }
 
-  public getExpectedPrivateKeyJwtAudience(): string {
-    return `${this.simulatorUrl}/token`;
+  public getExpectedPrivateKeyJwtAudiences(): string[] {
+    return [`${this.simulatorUrl}/token`, this.getIssuerValue()];
   }
 
   public getTrustmarkUrl(): string {

--- a/src/parse/parse-token-request.ts
+++ b/src/parse/parse-token-request.ts
@@ -115,18 +115,19 @@ export const parseTokenRequest = async (
 
   if (
     (typeof parsedClientAssertion.payload.aud === "string" &&
-      parsedClientAssertion.payload.aud !==
-        config.getExpectedPrivateKeyJwtAudience()) ||
+      !config
+        .getExpectedPrivateKeyJwtAudiences()
+        .includes(parsedClientAssertion.payload.aud)) ||
     (Array.isArray(parsedClientAssertion.payload.aud) &&
-      !parsedClientAssertion.payload.aud.includes(
-        config.getExpectedPrivateKeyJwtAudience()
+      !parsedClientAssertion.payload.aud.every((aud) =>
+        config.getExpectedPrivateKeyJwtAudiences().includes(aud)
       ))
   ) {
     //We need to error here to match the validation in the token handler
     //This matches the validation here https://github.com/govuk-one-login/authentication-api/blob/dc42596ab02184f80c30f327a7dcd0f76146e619/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ClientSignatureValidationService.java#L103 where the audience is validated in the client signature
     // validation service
     logger.warn(
-      `Invalid audience in client JWT assertion: Expected: ${config.getExpectedPrivateKeyJwtAudience()}, Received: ${parsedClientAssertion.payload.aud}`
+      `Invalid audience in client JWT assertion: Expected: ${config.getExpectedPrivateKeyJwtAudiences()}, Received: ${parsedClientAssertion.payload.aud}`
     );
 
     throw new TokenRequestError({

--- a/src/parse/tests/parse-token-request.test.ts
+++ b/src/parse/tests/parse-token-request.test.ts
@@ -29,6 +29,7 @@ const rsaKeyPair = generateKeyPairSync("rsa", {
 const testTimestamp = 1723707024;
 const knownClientId = "b1a80190cf07983fca7e46375385a8ed";
 const audience = "http://localhost:3000/token";
+const issuer = "http://localhost:3000/";
 
 describe("parseTokenRequest tests", () => {
   beforeEach(() => {
@@ -819,6 +820,57 @@ describe("parseTokenRequest tests", () => {
       exp: Math.floor(testTimestamp / 1000) + 300,
       iss: knownClientId,
       aud: audience,
+      jti: randomUUID(),
+    };
+
+    const clientAssertion = await new SignJWT(payload)
+      .setProtectedHeader(header)
+      .sign(rsaKeyPair.privateKey);
+
+    const tokenRequest = {
+      grant_type: "authorization_code",
+      code: "123456",
+      redirect_uri: "https://example.com/authentication-callback/",
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      client_assertion: clientAssertion,
+    };
+
+    const parsedTokenRequest = await parseTokenRequest(tokenRequest, config);
+
+    expect(parsedTokenRequest).toStrictEqual({
+      tokenRequest: {
+        grant_type: "authorization_code",
+        code: "123456",
+        redirectUri: "https://example.com/authentication-callback/",
+        client_assertion_type:
+          "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+        client_assertion: clientAssertion,
+      },
+      clientAssertion: {
+        header,
+        payload,
+        token: clientAssertion,
+        clientId: knownClientId,
+        signature: clientAssertion.split(".")[2],
+      },
+    });
+  });
+
+  it("returns a parsed tokenRequest and clientAssertion for a valid request with the issuer as the audience", async () => {
+    clientIdSpy.mockReturnValue(knownClientId);
+    const publicKey = await exportSPKI(rsaKeyPair.publicKey);
+    publicKeySpy.mockReturnValue(publicKey);
+    idTokenSigningSpy.mockReturnValue("RS256");
+
+    const header = {
+      alg: "RS256",
+    };
+    const payload = {
+      sub: knownClientId,
+      exp: Math.floor(testTimestamp / 1000) + 300,
+      iss: knownClientId,
+      aud: issuer,
       jti: randomUUID(),
     };
 


### PR DESCRIPTION
Replicates: https://github.com/govuk-one-login/authentication-api/pull/6490