### PR TITLE
ATO-1694: add validation to channel claim

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -82,3 +82,5 @@ export const AUTHORISE_ERRORS = ["ACCESS_DENIED"];
 
 export const INVALID_ISSUER = "https://example.com/identity-provider";
 export const ONE_DAY_IN_SECONDS = 86400;
+
+export const VALID_CHANNELS = ["web", "generic_app"];

--- a/src/parse/parse-auth-request.ts
+++ b/src/parse/parse-auth-request.ts
@@ -37,6 +37,7 @@ export type AuthRequest = {
   code_challenge_method?: string;
   response_mode?: string;
   login_hint?: string;
+  channel?: string;
 };
 
 export const parseAuthRequest = (

--- a/src/validators/tests/validate-auth-request-object.test.ts
+++ b/src/validators/tests/validate-auth-request-object.test.ts
@@ -459,6 +459,42 @@ describe("Validate auth request object tests", () => {
     );
   });
 
+  it("throw authorise request error when channel is invalid in request object", async () => {
+    const requestObject = requestObjectWithParams({
+      channel: "invalid-channel",
+    });
+    const authRequest = {
+      ...defaultAuthRequest,
+      requestObject,
+    };
+
+    await expect(
+      validateAuthRequestObject(authRequest, config)
+    ).rejects.toThrow(
+      new AuthoriseRequestError({
+        httpStatusCode: 302,
+        errorCode: "invalid_request",
+        errorDescription: "Invalid value for channel parameter.",
+        redirectUri: defaultRedirectUri,
+        state: defaultState,
+      })
+    );
+  });
+
+  it("not throw an error when channel is valid in request object", async () => {
+    const requestObject = requestObjectWithParams({
+      channel: "generic_app",
+    });
+    const authRequest = {
+      ...defaultAuthRequest,
+      requestObject,
+    };
+
+    await expect(
+      validateAuthRequestObject(authRequest, config)
+    ).resolves.not.toThrow();
+  });
+
   it("throw bad request error response_mode for unknown response_mode", async () => {
     const requestObject = requestObjectWithParams({
       response_mode: "code",

--- a/src/validators/tests/validate-auth-request-query-params.test.ts
+++ b/src/validators/tests/validate-auth-request-query-params.test.ts
@@ -194,6 +194,38 @@ describe("validateAuthRequestQueryParams tests", () => {
     );
   });
 
+  it("throws an invalid request error for an invalid channel", () => {
+    expect(() =>
+      validateAuthRequestQueryParams(
+        {
+          ...defaultAuthRequest,
+          channel: "invalid-channel",
+        },
+        config
+      )
+    ).toThrow(
+      new AuthoriseRequestError({
+        errorCode: "invalid_request",
+        errorDescription: "Invalid value for channel parameter.",
+        httpStatusCode: 302,
+        redirectUri: defaultAuthRequest.redirect_uri,
+        state: defaultAuthRequest.state,
+      })
+    );
+  });
+
+  it("does not throw an error for a valid channel", () => {
+    expect(() =>
+      validateAuthRequestQueryParams(
+        {
+          ...defaultAuthRequest,
+          channel: "generic_app",
+        },
+        config
+      )
+    ).not.toThrow();
+  });
+
   it("throw authorise request error when response mode is not query or fragment", () => {
     expect(() =>
       validateAuthRequestQueryParams(

--- a/src/validators/validate-auth-request-object.ts
+++ b/src/validators/validate-auth-request-object.ts
@@ -15,6 +15,7 @@ import { areScopesValid } from "./scope-validator";
 import { vtrValidator } from "./vtr-validator";
 import { areClaimsValid } from "./claims-validator";
 import { validatePKCECodeChallengeAndMethod } from "./code-challenge-validator";
+import { VALID_CHANNELS } from "../constants";
 
 export const validateAuthRequestObject = async (
   authRequest: AuthRequest,
@@ -187,6 +188,8 @@ export const validateAuthRequestObject = async (
 
   validateLoginHint(payload);
 
+  validateChannel(payload);
+
   logger.info("RequestObject has passed initial validation");
 };
 
@@ -253,6 +256,22 @@ const validateLoginHint = (payload: JWTPayload) => {
         httpStatusCode: 302,
         errorCode: "invalid_request",
         errorDescription: "login_hint parameter is invalid",
+        redirectUri: payload.redirect_uri as string,
+        state: payload.state as string,
+      });
+    }
+  }
+};
+
+const validateChannel = (payload: JWTPayload) => {
+  if (payload.channel) {
+    const parsedChannel = payload.channel as string;
+
+    if (parsedChannel !== null && !VALID_CHANNELS.includes(parsedChannel)) {
+      throw new AuthoriseRequestError({
+        errorCode: "invalid_request",
+        errorDescription: "Invalid value for channel parameter.",
+        httpStatusCode: 302,
         redirectUri: payload.redirect_uri as string,
         state: payload.state as string,
       });

--- a/src/validators/validate-auth-request-query-params.ts
+++ b/src/validators/validate-auth-request-query-params.ts
@@ -7,6 +7,7 @@ import { vtrValidator } from "./vtr-validator";
 import { Config } from "../config";
 import { AuthRequest } from "src/parse/parse-auth-request";
 import { validatePKCECodeChallengeAndMethod } from "./code-challenge-validator";
+import { VALID_CHANNELS } from "../constants";
 
 export const validateAuthRequestQueryParams = (
   queryParams: AuthRequest,
@@ -122,5 +123,15 @@ export const validateAuthRequestQueryParams = (
       queryParams.code_challenge,
       queryParams.code_challenge_method
     );
+  }
+
+  if (queryParams.channel && !VALID_CHANNELS.includes(queryParams.channel)) {
+    throw new AuthoriseRequestError({
+      errorCode: "invalid_request",
+      errorDescription: "Invalid value for channel parameter.",
+      httpStatusCode: 302,
+      redirectUri: queryParams.redirect_uri,
+      state: queryParams.state,
+    });
   }
 };

--- a/tests/integration/authorise-get-controller.test.ts
+++ b/tests/integration/authorise-get-controller.test.ts
@@ -1275,6 +1275,28 @@ describe("Authorise controller tests", () => {
         );
       });
 
+      it("returns a 302 with invalid request if the channel parameter in the request object is an invalid channel", async () => {
+        const app = createApp();
+        const requestParams = createRequestParams({
+          client_id: knownClientId,
+          redirect_uri: knownRedirectUri,
+          response_type: "code",
+          scope: "openid email",
+          request: await encodedJwtWithParams({
+            channel: "invalid-channel",
+          }),
+        });
+
+        const response = await request(app).get(
+          authoriseEndpoint + "?" + requestParams
+        );
+
+        expect(response.status).toBe(302);
+        expect(response.headers.location).toBe(
+          `${knownRedirectUri}?error=invalid_request&error_description=${encodeURIComponent("Invalid value for channel parameter.")}&state=${state}`
+        );
+      });
+
       it("returns a 302 with unmet authentication requirements if the prompt includes select_account", async () => {
         const app = createApp();
         const requestParams = createRequestParams({
@@ -1355,6 +1377,7 @@ describe("Authorise controller tests", () => {
               '{"userinfo": { "https://vocab.account.gov.uk/v1/coreIdentityJWT": { "essential": true }}}',
             ui_locales: "en",
             login_hint: "email@email.com",
+            channel: "generic_app",
           }),
         });
 


### PR DESCRIPTION
Add channel validation to simulator. A valid channel is either null, web, or generic_app.