### PR TITLE
ATO-1637: Remove reference to POST authorize requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The simulator aims to mirror GOV.UK One Login but does not support all of the fe
 
 - You **must** use the[`private_key_jwt` authentication method](https://openid.net/specs/openid-connect-core-1_0.html#:~:text=OAuth.JWT%5D.-,private_key_jwt,-Clients%20that%20have) at the `/token` endpoint
 - You **must** attach a `nonce` parameter in the `/authorize` request
-- You **must** use a `GET` request with either query parameters or a [request object](https://openid.net/specs/openid-connect-core-1_0.html#:~:text=%C2%A0TOC-,3.1.2.1.%C2%A0%20Authentication%20Request,-An%20Authentication%20Request) when making a request to `/authorize`. The simulator does not support the `POST` method for authorization requests.
+- You **must** use a `GET` request with either query parameters or a [request object](https://openid.net/specs/openid-connect-core-1_0.html#:~:text=%C2%A0TOC-,3.1.2.1.%C2%A0%20Authentication%20Request,-An%20Authentication%20Request) when making a request to `/authorize`.
 
 ## Documentation:
 


### PR DESCRIPTION
Context: The readme for Simulator points out that although Simulator mirrors One Login in most respects, Simulator doesn't include support for POST /authorize requests. But as we are now removing support for POST requests from One Login, this line can be removed from the Simulator readme.

- remove mention in the readme to not supporting POST /authorize requests.