### PR TITLE
ATO-1784: Add `temporarily_unavailable` error to config

### DIFF
--- a/docs/configured-errors.md
+++ b/docs/configured-errors.md
@@ -26,6 +26,7 @@ These are errors returned at the point in which a user hits the `/authorize` end
 | Error type    | Description                                                                                                                                                                                            |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | ACCESS_DENIED | Returns the access denied error that would be returned to an RP when a user has issues with identity, but does not have return codes switched on. It is returned just before an auth code is generated |
+| TEMPORARILY_UNAVAILABLE | Returns the temporarily unavailable error that would be returned to an RP when an RP is being rate limited. It is returned just after the authorisation request is validated |
 
 #### ID token errors:
 

--- a/src/components/authorise/authorise-get-controller.ts
+++ b/src/components/authorise/authorise-get-controller.ts
@@ -75,6 +75,19 @@ export const authoriseController = async (
       });
     }
 
+    if (config.getAuthoriseErrors().includes("TEMPORARILY_UNAVAILABLE")) {
+      logger.warn(
+        "Client configured to return temporarily_unavailable error response"
+      );
+      throw new AuthoriseRequestError({
+        errorCode: "temporarily_unavailable",
+        errorDescription: "",
+        httpStatusCode: 302,
+        redirectUri: parsedAuthRequest.redirect_uri,
+        state: parsedAuthRequest.state,
+      });
+    }
+
     const authCode = generateAuthCode();
     const authRequestParams = {
       claims: parsedAuthRequest.claims,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -78,7 +78,7 @@ export const ID_TOKEN_ERRORS = [
   "INCORRECT_VOT",
 ];
 
-export const AUTHORISE_ERRORS = ["ACCESS_DENIED"];
+export const AUTHORISE_ERRORS = ["ACCESS_DENIED", "TEMPORARILY_UNAVAILABLE"];
 
 export const INVALID_ISSUER = "https://example.com/identity-provider";
 export const ONE_DAY_IN_SECONDS = 86400;

--- a/src/types/authorise-errors.ts
+++ b/src/types/authorise-errors.ts
@@ -1,1 +1,1 @@
-export type AuthoriseError = "ACCESS_DENIED";
+export type AuthoriseError = "ACCESS_DENIED" | "TEMPORARILY_UNAVAILABLE";

--- a/tests/integration/authorise-get-controller.test.ts
+++ b/tests/integration/authorise-get-controller.test.ts
@@ -517,6 +517,31 @@ describe("Authorise controller tests", () => {
         );
       });
 
+      it("returns 302 and redirects with a temporarily_unavailable error when the client has enabled TEMPORARILY_UNAVAILABLE", async () => {
+        jest
+          .spyOn(Config.getInstance(), "getAuthoriseErrors")
+          .mockReturnValue(["TEMPORARILY_UNAVAILABLE"]);
+
+        const app = createApp();
+        const requestParams = createRequestParams({
+          client_id: knownClientId,
+          redirect_uri: knownRedirectUri,
+          response_type: "code",
+          scope: "openid email",
+          state,
+          nonce,
+        });
+
+        const response = await request(app).get(
+          authoriseEndpoint + "?" + requestParams
+        );
+
+        expect(response.status).toBe(302);
+        expect(response.header.location).toBe(
+          `${knownRedirectUri}?error=temporarily_unavailable&error_description=&state=${state}`
+        );
+      });
+
       it("returns 302 and redirect with an auth code for a valid minimal auth request", async () => {
         const app = createApp();
         const requestParams = createRequestParams({


### PR DESCRIPTION
This error is returned when an RP is being rate limited. Name of error subject to change as the implementation is not done yet