### PR TITLE
ATO-1855: Add `kid` to header of `INVALID_ALG_HEADER` id token

### DIFF
--- a/acceptance-tests-local.docker-compose.yaml
+++ b/acceptance-tests-local.docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
   simulator:
     container_name: simulator
+    env_file: ".env"
     build:
       context: .
       dockerfile: Dockerfile

--- a/src/components/token/tests/helper/create-id-token.test.ts
+++ b/src/components/token/tests/helper/create-id-token.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../../constants";
 import AuthRequestParameters from "../../../../types/auth-request-parameters";
 import { createIdToken } from "../../helper/create-id-token";
+import { INVALID_KEY_KID } from "../../../utils/make-header-invalid";
 
 describe("createIdToken tests", () => {
   const mockAuthRequestParams: AuthRequestParameters = {
@@ -169,6 +170,7 @@ describe("createIdToken tests", () => {
 
     expect(tokenParts.length).toBe(3);
     expect(header).toStrictEqual({
+      kid: INVALID_KEY_KID,
       alg: "HS256",
     });
   });

--- a/src/components/utils/make-header-invalid.ts
+++ b/src/components/utils/make-header-invalid.ts
@@ -1,6 +1,8 @@
-export const makeHeaderInvalid = (signedJwt: string): string => {
+const INVALID_KEY_KID = "60c01993-94cd-4d32-a4da-2a44dba7e45b";
+const makeHeaderInvalid = (signedJwt: string): string => {
   const invalidHeader = Buffer.from(
     JSON.stringify({
+      kid: INVALID_KEY_KID,
       alg: "HS256",
     })
   ).toString("base64url");
@@ -8,3 +10,5 @@ export const makeHeaderInvalid = (signedJwt: string): string => {
   const jwtParts = signedJwt.split(".");
   return [invalidHeader, jwtParts[1], jwtParts[2]].join(".");
 };
+
+export { INVALID_KEY_KID, makeHeaderInvalid };

--- a/src/components/utils/tests/make-header-invalid.test.ts
+++ b/src/components/utils/tests/make-header-invalid.test.ts
@@ -1,4 +1,4 @@
-import { makeHeaderInvalid } from "../make-header-invalid";
+import { INVALID_KEY_KID, makeHeaderInvalid } from "../make-header-invalid";
 
 describe("makeHeaderInvalid tests", () => {
   const testToken =
@@ -11,6 +11,7 @@ describe("makeHeaderInvalid tests", () => {
       Buffer.from(header, "base64url").toString()
     );
     expect(parsedHeader).toStrictEqual({
+      kid: INVALID_KEY_KID,
       alg: "HS256",
     });
   });

--- a/tests/integration/token-controller.test.ts
+++ b/tests/integration/token-controller.test.ts
@@ -22,6 +22,7 @@ import {
 } from "../../src/constants";
 import { decodeJwtNoVerify } from "./helper/decode-jwt-no-verify";
 import { exampleResponseConfig } from "./helper/test-constants";
+import { INVALID_KEY_KID } from "../../src/components/utils/make-header-invalid";
 
 const TOKEN_ENDPOINT = "/token";
 
@@ -501,6 +502,7 @@ describe("/token endpoint, configured error responses", () => {
     const { id_token } = response.body;
     const { protectedHeader } = decodeJwtNoVerify(id_token);
     expect(protectedHeader).toStrictEqual({
+      kid: INVALID_KEY_KID,
       alg: "HS256",
     });
   });


### PR DESCRIPTION
This PR adds a `kid` field to the header of the ID token sent when the `INVALID_ALG_HEADER` error is enabled in the simulator (resolves https://github.com/govuk-one-login/simulator/issues/323)