### PR TITLE
BAU: Move .eslintignores into .eslintrc.json

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,0 @@
-*.d.ts
-# don't ever lint node_modules
-node_modules
-dist

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,5 +35,10 @@
       "typescript": true,
       "node": true
     }
-  }
+  },
+  "ignorePatterns": [
+    "*.d.ts",
+    "node_modules",
+    "dist"
+  ]
 }


### PR DESCRIPTION
The use of the`.eslintignore` file is deprecated in a version we'd like to update to, so i've moved this into the `.eslintrc` config file. 