### PR TITLE
ATO-1951: Add missing did controller id to header in INVALID_ALG_HEADER response

### DIFF
--- a/src/components/user-info/user-info-controller.ts
+++ b/src/components/user-info/user-info-controller.ts
@@ -206,7 +206,7 @@ const tryAddCoreIdentityJwt = async (
       .sign(signingKey);
     coreIdentityJwt = !coreIdentityErrors.includes("INVALID_ALG_HEADER")
       ? coreIdentityJwt
-      : makeHeaderInvalid(coreIdentityJwt);
+      : makeHeaderInvalid(coreIdentityJwt, config.getDidController());
 
     coreIdentityJwt = !coreIdentityErrors.includes("INVALID_SIGNATURE")
       ? coreIdentityJwt

--- a/src/components/utils/make-header-invalid.ts
+++ b/src/components/utils/make-header-invalid.ts
@@ -1,9 +1,16 @@
 const INVALID_KEY_KID = "60c01993-94cd-4d32-a4da-2a44dba7e45b";
-const makeHeaderInvalid = (signedJwt: string): string => {
+const makeHeaderInvalid = (
+  signedJwt: string,
+  didController?: string
+): string => {
+  let kid = INVALID_KEY_KID;
+  if (didController != null) {
+    kid = `${didController}#${INVALID_KEY_KID}`;
+  }
   const invalidHeader = Buffer.from(
     JSON.stringify({
-      kid: INVALID_KEY_KID,
       alg: "HS256",
+      kid,
     })
   ).toString("base64url");
 

--- a/tests/integration/user-info.test.ts
+++ b/tests/integration/user-info.test.ts
@@ -553,6 +553,9 @@ describe("/userinfo endpoint with identity verification enabled", () => {
       response.body["https://vocab.account.gov.uk/v1/coreIdentityJWT"];
     const { protectedHeader } = await decodeJwtNoVerify(coreIdentityJwt);
     expect(protectedHeader.alg).not.toEqual("ES256");
+    expect(protectedHeader.kid).toStrictEqual(
+      "did:web:localhost%3A3000#60c01993-94cd-4d32-a4da-2a44dba7e45b"
+    );
   });
 
   it("for scenario INVALID_SIGNATURE: returns coreIdentityJWT with invalid signature", async () => {


### PR DESCRIPTION
Resolves https://github.com/govuk-one-login/simulator/issues/342

Also adds unit test coverage for this