### PR TITLE
BAU: Improve dependency management  

### DIFF
--- a/.github/workflows/pre-merge-and-main-checks.yml
+++ b/.github/workflows/pre-merge-and-main-checks.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get NPM version
         run: echo "Using npm:$(npm -version)"
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Build app
         run: npm run build
 
@@ -46,11 +46,11 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Install micro RP dependencies
         run: |
           cd tests/acceptance/micro-rp
-          npm install 
+          npm ci 
           cd ../../..
       - name: Run lint
         run: npm run check:lint
@@ -73,7 +73,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Run tests
         run: npm run test
       - name: Report coverage

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Get NPM version
         run: echo "Using npm:$(npm -version)"
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Run acceptance tests
         run: npm run acceptance-test
       - name: Notify on failure

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:24.7.0@sha256:701c8a634cb3ddbc1dc9584725937619716882525356f0989f11816ba3747a22 as base
 WORKDIR /app
 COPY . ./
-RUN npm install 
+RUN npm ci 
 RUN npm run build
 
 FROM node:24.7.0@sha256:701c8a634cb3ddbc1dc9584725937619716882525356f0989f11816ba3747a22 as release

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /app
 COPY . ./
 RUN npm ci 
 RUN npm run build
+RUN npm ci --omit=dev
 
 FROM node:24.7.0@sha256:701c8a634cb3ddbc1dc9584725937619716882525356f0989f11816ba3747a22 as release
 WORKDIR /app

--- a/tests/acceptance/micro-rp/Dockerfile
+++ b/tests/acceptance/micro-rp/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22.9.0@sha256:69e667a79aa41ec0db50bc452a60e705ca16f35285eaf037ebe627a65a5cdf52 as base
 WORKDIR /app
 COPY . ./
-RUN npm install
+RUN npm ci 
 RUN npm run build
 
 FROM node:22.9.0@sha256:69e667a79aa41ec0db50bc452a60e705ca16f35285eaf037ebe627a65a5cdf52 as release

--- a/tests/acceptance/micro-rp/Dockerfile
+++ b/tests/acceptance/micro-rp/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /app
 COPY . ./
 RUN npm ci 
 RUN npm run build
+RUN npm ci --omit=dev
 
 FROM node:22.9.0@sha256:69e667a79aa41ec0db50bc452a60e705ca16f35285eaf037ebe627a65a5cdf52 as release
 WORKDIR /app


### PR DESCRIPTION
Adds a few things to improve the way we manage dependencies, namely:
- Use `npm ci` in CI/CD infra and Dockerfiles to ensure builds respect the lockfile 
- Omit dev dependencies from the final image
-  Add an .npmrc file which has the `ignore-scripts=true` to ensure we ignore any lifecycle scripts from pulled in dependencies 