### PR TITLE
BAU: Update minimum pino version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "express": "^4.21.2",
         "express-validator": "^7.2.0",
         "jose": "^5.9.6",
-        "pino": "^9.5.0"
+        "pino": "^9.12.0"
       },
       "devDependencies": {
         "@cucumber/cucumber": "^12.1.0",
@@ -4271,14 +4271,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
-    "node_modules/fast-redact": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
@@ -6987,19 +6979,20 @@
       }
     },
     "node_modules/pino": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.5.0.tgz",
-      "integrity": "sha512-xSEmD4pLnV54t0NOUN16yCl7RIB1c5UUOse5HSyEXtBp+FgFQyPeDutc+Q2ZO7/22vImV7VfEjH/1zV2QuqvYw==",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.13.1.tgz",
+      "integrity": "sha512-Szuj+ViDTjKPQYiKumGmEn3frdl+ZPSdosHyt9SnUevFosOkMY2b7ipxlEctNKPmMD/VibeBI+ZcZCJK+4DPuw==",
+      "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.1.1",
         "on-exit-leak-free": "^2.1.0",
         "pino-abstract-transport": "^2.0.0",
         "pino-std-serializers": "^7.0.0",
-        "process-warning": "^4.0.0",
+        "process-warning": "^5.0.0",
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.2.0",
         "safe-stable-stringify": "^2.3.1",
+        "slow-redact": "^0.3.0",
         "sonic-boom": "^4.0.1",
         "thread-stream": "^3.0.0"
       },
@@ -7172,9 +7165,20 @@
       "dev": true
     },
     "node_modules/process-warning": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.0.tgz",
-      "integrity": "sha512-/MyYDxttz7DfGMMHiysAsFE4qF+pQYAA8ziO/3NcRVrQ5fSk+Mns4QZA/oRPFzvcqNoVJXQNWNAsdwBXLUkQKw=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -7832,6 +7836,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/slow-redact": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.0.tgz",
+      "integrity": "sha512-cf723wn9JeRIYP9tdtd86GuqoR5937u64Io+CYjlm2i7jvu7g0H+Cp0l0ShAf/4ZL+ISUTVT+8Qzz7RZmp9FjA==",
+      "license": "MIT"
     },
     "node_modules/sonic-boom": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "express": "^4.21.2",
     "express-validator": "^7.2.0",
     "jose": "^5.9.6",
-    "pino": "^9.5.0"
+    "pino": "^9.12.0"
   },
   "devDependencies": {
     "@cucumber/cucumber": "^12.1.0",
@@ -52,5 +52,8 @@
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.3"
+  },
+  "overrides": {
+    "pino": "^9.12.0"
   }
 }

--- a/src/components/form-submit/form-submit-controller.ts
+++ b/src/components/form-submit/form-submit-controller.ts
@@ -62,8 +62,7 @@ export const formSubmitController = (req: Request, res: Response): void => {
     );
   } catch (error) {
     logger.error(
-      "Failed to put form configuration: ",
-      (error as Error).message
+      `Failed to put form configuration: ${(error as Error).message}`
     );
     res.status(400);
     res.json({

--- a/src/components/logout/logout-controller.ts
+++ b/src/components/logout/logout-controller.ts
@@ -178,9 +178,8 @@ const isValidUrl = (url: string): boolean => {
     new URL(url);
     return true;
   } catch (error) {
-    logger.warn(
-      "Post logout redirect uri is not valid url: " + url,
-      "error: " + (error as Error).message
+    logger.error(
+      `Post logout redirect uri is not valid url: ${url} error: ${(error as Error).message}`
     );
     return false;
   }

--- a/src/parse/parse-token-request.ts
+++ b/src/parse/parse-token-request.ts
@@ -330,7 +330,7 @@ const isSignatureValid = async (
     await jwtVerify(token, parsedPublicKey);
     return true;
   } catch (error) {
-    logger.error("Error validating signature", error);
+    logger.error(`Error validating signature: ${(error as Error).message}`);
     return false;
   }
 };

--- a/src/validators/signed-jwt-validator.ts
+++ b/src/validators/signed-jwt-validator.ts
@@ -25,7 +25,7 @@ export const signedJwtValidator = async <PayloadType = JWTPayload>(
       payload: payload,
     };
   } catch (error) {
-    logger.error("Error validating signature", error);
+    logger.error(`Error validating signature: ${(error as Error).message}`);
     return { valid: false };
   }
 };


### PR DESCRIPTION
- Pino versions prior to 9.12.0 were depending on `fast-redact`, which was vulnerable to prototype pollution (https://github.com/govuk-one-login/simulator/security/dependabot/16). 
- [Pino v9.12.0](https://github.com/pinojs/pino/releases/tag/v9.12.0) replaces `fast-redact` with `slow-redact`, so i've set this as the minimum version