### PR TITLE
BAU: Run tests only on weekdays

### DIFF
--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -2,7 +2,7 @@ name: Run Acceptance Tests
 
 on:
   schedule:
-    - cron: "0 15 * * *"
+    - cron: "0 15 * * 1-5"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
They tend to fail on weekends and they don't provide much value as they don't indicate anything urgent and are therefore not monitored