### PR TITLE
ATO-2465: Add extra validation for identity LoCs

### DIFF
--- a/src/validators/tests/vtr-validator.test.ts
+++ b/src/validators/tests/vtr-validator.test.ts
@@ -6,6 +6,10 @@ describe("vtrValidator tests", () => {
   const config = Config.getInstance();
 
   const levelOfConfidenceSpy = jest.spyOn(config, "getClientLoCs");
+  const identityVerificationSupportedSpy = jest.spyOn(
+    config,
+    "getIdentityVerificationSupported"
+  );
   const state = "4063a64d651d9077adee7c51a26e87e8";
   const redirectUri = "https://example.com/authentication-callback";
 
@@ -209,8 +213,26 @@ describe("vtrValidator tests", () => {
     );
   });
 
+  it("throws an error when an identity vtr is requested and the client has identity verification not supported", () => {
+    levelOfConfidenceSpy.mockReturnValue(["P0", "P2"]);
+    identityVerificationSupportedSpy.mockReturnValue(false);
+
+    expect(() =>
+      vtrValidator('["Cl.Cm.P2"]', config, state, redirectUri)
+    ).toThrow(
+      new AuthoriseRequestError({
+        errorCode: "invalid_request",
+        errorDescription: "Request vtr not valid",
+        httpStatusCode: 302,
+        state,
+        redirectUri,
+      })
+    );
+  });
+
   it("returns a parsed valid vtr set", () => {
     levelOfConfidenceSpy.mockReturnValue(["P1", "P2", "P3"]);
+    identityVerificationSupportedSpy.mockReturnValue(true);
 
     expect(
       vtrValidator(

--- a/src/validators/vtr-validator.ts
+++ b/src/validators/vtr-validator.ts
@@ -62,6 +62,15 @@ export const vtrValidator = (
     );
     throw generateInvalidVtrError(redirectUri, state);
   }
+  if (
+    identityVectors.length > 0 &&
+    !config.getIdentityVerificationSupported()
+  ) {
+    logger.error(
+      "Level of confidence values for an identity journey have been requested, but identity is not supported for this client."
+    );
+    throw generateInvalidVtrError(redirectUri, state);
+  }
 
   return parsedVtrSet;
 };


### PR DESCRIPTION
We have recently made a change in the production code to reject requests with identity LoCs where the client has identity verification supported set to false (see PR here: https://github.com/govuk-one-login/authentication-api/pull/8127). 
This is replicating this validation in the simulator, along with a test.

