### PR TITLE
ATO 2506 Validate vtr against token auth method

### DIFF
--- a/src/validators/tests/vtr-validator.test.ts
+++ b/src/validators/tests/vtr-validator.test.ts
@@ -10,6 +10,7 @@ describe("vtrValidator tests", () => {
     config,
     "getIdentityVerificationSupported"
   );
+  const tokenAuthMethodSpy = vi.spyOn(config, "getTokenAuthMethod");
   const state = "4063a64d651d9077adee7c51a26e87e8";
   const redirectUri = "https://example.com/authentication-callback";
 
@@ -230,9 +231,28 @@ describe("vtrValidator tests", () => {
     );
   });
 
+  it("throws an error when an identity journey is requested with an incompatible tokenAuthMethod", () => {
+    levelOfConfidenceSpy.mockReturnValue(["P0", "P2"]);
+    identityVerificationSupportedSpy.mockReturnValue(true);
+    tokenAuthMethodSpy.mockReturnValue("client_secret_post");
+
+    expect(() =>
+      vtrValidator('["Cl.Cm.P2"]', config, state, redirectUri)
+    ).toThrow(
+      new AuthoriseRequestError({
+        errorCode: "invalid_request",
+        errorDescription: "Request vtr not valid",
+        httpStatusCode: 302,
+        state,
+        redirectUri,
+      })
+    );
+  });
+
   it("returns a parsed valid vtr set", () => {
     levelOfConfidenceSpy.mockReturnValue(["P1", "P2", "P3"]);
     identityVerificationSupportedSpy.mockReturnValue(true);
+    tokenAuthMethodSpy.mockReturnValue("private_key_jwt");
 
     expect(
       vtrValidator(

--- a/src/validators/tests/vtr-validator.test.ts
+++ b/src/validators/tests/vtr-validator.test.ts
@@ -14,6 +14,10 @@ describe("vtrValidator tests", () => {
   const state = "4063a64d651d9077adee7c51a26e87e8";
   const redirectUri = "https://example.com/authentication-callback";
 
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
   it("returns the default credential trust and level of confidence when vtr is undefined", () => {
     levelOfConfidenceSpy.mockReturnValue(["P0", "P2"]);
 
@@ -233,7 +237,6 @@ describe("vtrValidator tests", () => {
 
   it("throws an error when an identity journey is requested with an incompatible tokenAuthMethod", () => {
     levelOfConfidenceSpy.mockReturnValue(["P0", "P2"]);
-    identityVerificationSupportedSpy.mockReturnValue(true);
     tokenAuthMethodSpy.mockReturnValue("client_secret_post");
 
     expect(() =>
@@ -251,8 +254,6 @@ describe("vtrValidator tests", () => {
 
   it("returns a parsed valid vtr set", () => {
     levelOfConfidenceSpy.mockReturnValue(["P1", "P2", "P3"]);
-    identityVerificationSupportedSpy.mockReturnValue(true);
-    tokenAuthMethodSpy.mockReturnValue("private_key_jwt");
 
     expect(
       vtrValidator(

--- a/src/validators/vtr-validator.ts
+++ b/src/validators/vtr-validator.ts
@@ -74,6 +74,15 @@ export const vtrValidator = (
     );
     throw generateInvalidVtrError(redirectUri, state);
   }
+  if (
+    identityVectors.length > 0 &&
+    "client_secret_post" == config.getTokenAuthMethod()
+  ) {
+    logger.error(
+      "Request contains level of confidence values for an identity journey but the tokenAuthMethod is incompatible."
+    );
+    throw generateInvalidVtrError(redirectUri, state);
+  }
 
   return parsedVtrSet;
 };


### PR DESCRIPTION
The Authorisation lambda is going to start rejecting identity requests made by clients using `client_post_secret` as their `tokenAuthMethod`.  This PR is to keep the functionality of the Simulator aligned with the behaviour of the main system.