### PR TITLE
BAU: Fix acceptance test failures

### DIFF
--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -46,7 +46,7 @@ jobs:
         run: npm run acceptance-test
       - name: Notify on failure
         if: ${{ failure() }}
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger

--- a/tests/acceptance/features/identity.feature
+++ b/tests/acceptance/features/identity.feature
@@ -9,8 +9,8 @@ Feature: Identity
     When the user enters their password
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user enters the six digit security code from their authenticator app
-    Then the user is taken to the "You have already proved your identity" page
-    When the user clicks the "Continue to the service" button
+    Then the user is taken to the "Confirm your details" page
+    When the user clicks the "Confirm and continue" button
     Then the user is returned to the service with extended timeout
     And the RP receives a valid ID Token
     And the RP receives the expected identity user info

--- a/tests/acceptance/pages/base-page.js
+++ b/tests/acceptance/pages/base-page.js
@@ -11,28 +11,43 @@ export default class BasePage {
   }
 
   waitForPageLoad = async (titleContains) => {
-    await this.page.wait(until.titleContains(titleContains), this.DEFAULT_PAGE_LOAD_WAIT_TIME);
+    await this.page.wait(
+      until.titleContains(titleContains),
+      this.DEFAULT_PAGE_LOAD_WAIT_TIME
+    );
     await this.waitForReadyStateComplete();
   };
 
   findAndClickContinue = async () => {
     await this.waitForReadyStateComplete();
-    const continueButton = this.page.findElement(By.xpath("//button[text()[normalize-space() = 'Continue']]"));
+    const continueButton = this.page.findElement(
+      By.xpath("//button[text()[normalize-space() = 'Continue']]")
+    );
     await continueButton.click();
   };
 
   findAndClickButtonByText = async (buttonText) => {
     await this.waitForReadyStateComplete();
-    const button = this.page.findElement(
-      By.xpath("//button[text()[normalize-space() = '" + buttonText + "']]")
-    );
-    await button.click();
+    try {
+      const button = await this.page.findElement(
+        By.xpath("//button[text()[normalize-space() = '" + buttonText + "']]")
+      );
+      await button.click();
+    } catch {
+      // Cannot find button, looking for fake buttons using <a> tags...
+      const link = await this.page.findElement(
+        By.xpath("//a[text()[normalize-space() = '" + buttonText + "']]")
+      );
+      await link.click();
+    }
   };
 
   waitForThisText = async (expectedText) => {
     await this.page.wait(
       until.elementIsVisible(
-        this.page.findElement(By.xpath("//*[contains(text(), '" + expectedText + "')]"))
+        this.page.findElement(
+          By.xpath("//*[contains(text(), '" + expectedText + "')]")
+        )
       )
     );
   };
@@ -45,7 +60,9 @@ export default class BasePage {
   waitForReadyStateComplete = async () => {
     const startTime = Date.now();
     while (Date.now() - startTime < this.DEFAULT_PAGE_LOAD_WAIT_TIME) {
-      const isPageLoaded = await this.page.executeScript("return document.readyState") === "complete";
+      const isPageLoaded =
+        (await this.page.executeScript("return document.readyState")) ===
+        "complete";
 
       if (isPageLoaded) {
         return;


### PR DESCRIPTION
The IPV identity reuse page has been updated, which was causing the acceptance tests to fail. This PR updates the tests to look for the updated titles/buttons

Also bumps the slack-github-action to avoid using node 20 (now deprecated)